### PR TITLE
Support for localized classes in WoW

### DIFF
--- a/src/main.lua
+++ b/src/main.lua
@@ -1,4 +1,5 @@
 MegaMacroCachedClass = nil
+MegaMacroCachedClassFull = nil
 MegaMacroCachedSpecialization = nil
 MegaMacroFullyActive = false
 MegaMacroSystemTime = GetTime()
@@ -33,7 +34,7 @@ local function Initialize()
 
     local specIndex = GetSpecialization()
     if specIndex then
-        MegaMacroCachedClass = UnitClass("player")
+        MegaMacroCachedClassFull, MegaMacroCachedClass = UnitClass("player")
         MegaMacroCachedSpecialization = select(2, GetSpecializationInfo(specIndex))
 
         MegaMacroCodeInfo.ClearAll()

--- a/src/windows/mega-macro.window.lua
+++ b/src/windows/mega-macro.window.lua
@@ -87,7 +87,7 @@ end
 
 local function InitializeTabs()
 	local playerName = UnitName("player")
-	MegaMacro_FrameTab2:SetText(MegaMacroCachedClass)
+	MegaMacro_FrameTab2:SetText(MegaMacroCachedClassFull)
 	MegaMacro_FrameTab4:SetText(playerName)
 
 	if MegaMacroCachedSpecialization == '' then


### PR DESCRIPTION
In french, classes are different for Male/Female characters. This means macros are not shared between male and female characters of the same class.
Example :
Druid (M) is Druide
Druid (F) is Druidesse

Same for almost all the others classes.

This PR fixes that. Based on https://wowwiki-archive.fandom.com/wiki/API_UnitClass.