### PR TITLE
Fixes to window icons and click event

### DIFF
--- a/MegaMacro.toc
+++ b/MegaMacro.toc
@@ -24,6 +24,5 @@ src/engine/parsing/conditions.lua
 src/engine/mega-macro-parser.lua
 
 src/windows/mega-macro.window.xml
-src/windows/mega-macro.window.lua
 
 src/main.lua

--- a/src/engine/mega-macro-engine.lua
+++ b/src/engine/mega-macro-engine.lua
@@ -120,7 +120,7 @@ end
 local function GetMacroStubCode(macroId)
     return
         GenerateIdPrefix(macroId).."\n"..
-        "/click [btn:1] "..ClickyFrameName..macroId.."\n"..
+        "/click [btn:1] "..ClickyFrameName..macroId.." LeftButton\n"..
         "/click [btn:2] "..ClickyFrameName..macroId.." RightButton\n"..
         "/click [btn:3] "..ClickyFrameName..macroId.." MiddleButton\n"..
         "/click [btn:4] "..ClickyFrameName..macroId.." Button4\n"..

--- a/src/engine/mega-macro-engine.lua
+++ b/src/engine/mega-macro-engine.lua
@@ -118,9 +118,11 @@ local function TryImportCharacterMacros()
 end
 
 local function GetMacroStubCode(macroId)
+    -- Fix a bug that causes click events not to register only when CVar ActionButtonUseKeyDown is set to 1. 
+    local primaryMacroButtonClickValue = GetCVar("ActionButtonUseKeyDown") == "1" and " LeftButton" or " " 
     return
         GenerateIdPrefix(macroId).."\n"..
-        "/click [btn:1] "..ClickyFrameName..macroId.." LeftButton\n"..
+        "/click [btn:1] "..ClickyFrameName..macroId..primaryMacroButtonClickValue.."\n"..
         "/click [btn:2] "..ClickyFrameName..macroId.." RightButton\n"..
         "/click [btn:3] "..ClickyFrameName..macroId.." MiddleButton\n"..
         "/click [btn:4] "..ClickyFrameName..macroId.." Button4\n"..

--- a/src/main.lua
+++ b/src/main.lua
@@ -1,5 +1,4 @@
 MegaMacroCachedClass = nil
-MegaMacroCachedClassFull = nil
 MegaMacroCachedSpecialization = nil
 MegaMacroFullyActive = false
 MegaMacroSystemTime = GetTime()
@@ -34,7 +33,7 @@ local function Initialize()
 
     local specIndex = GetSpecialization()
     if specIndex then
-        MegaMacroCachedClassFull, MegaMacroCachedClass = UnitClass("player")
+        MegaMacroCachedClass = UnitClass("player")
         MegaMacroCachedSpecialization = select(2, GetSpecializationInfo(specIndex))
 
         MegaMacroCodeInfo.ClearAll()

--- a/src/main.lua
+++ b/src/main.lua
@@ -43,6 +43,8 @@ local function Initialize()
         MegaMacroFullyActive = MegaMacroGlobalData.Activated and MegaMacroCharacterData.Activated
         f:SetScript("OnUpdate", OnUpdate)
     end
+
+    MegaMacro_RegisterShiftClicks()
 end
 
 f:SetScript("OnEvent", function(self, event)

--- a/src/windows/mega-macro.window.lua
+++ b/src/windows/mega-macro.window.lua
@@ -736,29 +736,32 @@ function MegaMacro_IconSearchBox_TextChanged()
 	UpdateIconList()
 end
 
-MegaMacroLastShiftClickInsertAt = nil
--- hooksecurefunc("SpellButton_OnModifiedClick", function(self)
--- 	-- for some reason this callback is triggered twice, this will prevent that
--- 	if MegaMacroSystemTime == MegaMacroLastShiftClickInsertAt then
--- 		return
--- 	end
+function MegaMacro_RegisterShiftClicks()
+	function shiftClickHookFunction(self) 
+		local slot = SpellBook_GetSpellBookSlot(self);
+		if ( slot > MAX_SPELLS ) then
+			return
+		end
+	
+		if IsModifiedClick("CHATLINK") and MegaMacro_FrameText:HasFocus() then
+			local spellName, subSpellName = GetSpellBookItemName(slot, SpellBookFrame.bookType)
+	
+			if spellName and not IsPassiveSpell(slot, SpellBookFrame.bookType) then
+				if subSpellName and string.len(subSpellName) > 0 then
+					MegaMacro_FrameText:Insert(spellName.."("..subSpellName..")")
+				else
+					MegaMacro_FrameText:Insert(spellName)
+				end
+			end
+		end
+	end
+	
+	-- This is a kind of a hack, but it gets the shift click to work. We loop through all the spellbook buttons and hook their OnClick functions individually, since the generic SpellButton_OnModifiedClick was removed.
+	for i = 1, 120 do
+		local buttonName = "SpellButton" .. i
+		if _G[buttonName] ~= nil then
+			hooksecurefunc(_G[buttonName], "OnModifiedClick", shiftClickHookFunction)
+		end
+	end
+end
 
--- 	MegaMacroLastShiftClickInsertAt = MegaMacroSystemTime
-
--- 	local slot = SpellBook_GetSpellBookSlot(self);
--- 	if ( slot > MAX_SPELLS ) then
--- 		return
--- 	end
-
--- 	if IsModifiedClick("CHATLINK") and MegaMacro_FrameText:HasFocus() then
--- 		local spellName, subSpellName = GetSpellBookItemName(slot, SpellBookFrame.bookType)
-
--- 		if spellName and not IsPassiveSpell(slot, SpellBookFrame.bookType) then
--- 			if subSpellName and string.len(subSpellName) > 0 then
--- 				MegaMacro_FrameText:Insert(spellName.."("..subSpellName..")")
--- 			else
--- 				MegaMacro_FrameText:Insert(spellName)
--- 			end
--- 		end
--- 	end
--- end)

--- a/src/windows/mega-macro.window.lua
+++ b/src/windows/mega-macro.window.lua
@@ -41,7 +41,7 @@ end
 
 local function GetMacroButtonUI(index)
 	local buttonName = "MegaMacro_MacroButton" .. index
-	return _G[buttonName], _G[buttonName .. "Name"], _G[buttonName .. "Icon"]
+	return _G[buttonName], _G[buttonName .. "Name"], _G[buttonName].Icon
 end
 
 -- Creates the button frames for the macro slots
@@ -87,7 +87,7 @@ end
 
 local function InitializeTabs()
 	local playerName = UnitName("player")
-	MegaMacro_FrameTab2:SetText(MegaMacroCachedClassFull)
+	MegaMacro_FrameTab2:SetText(MegaMacroCachedClass)
 	MegaMacro_FrameTab4:SetText(playerName)
 
 	if MegaMacroCachedSpecialization == '' then
@@ -225,7 +225,7 @@ local function SetMacroItems()
 		if macro then
 			buttonFrame.Macro = macro
 			buttonFrame.IsNewButton = false
-			buttonFrame:SetHighlightTexture("Interface\\Buttons\\ButtonHilight-Square", "ADD")
+			-- buttonFrame:SetHighlightTexture("Interface\\Buttons\\ButtonHilight-Square", "ADD")
 			buttonName:SetText(macro.DisplayName)
 			local data = MegaMacroIconEvaluator.GetCachedData(macro.Id)
 			buttonIcon:SetTexture(data and data.Icon)
@@ -235,7 +235,7 @@ local function SetMacroItems()
 		elseif not newMacroButtonCreated then
 			buttonFrame.Macro = nil
 			buttonFrame.IsNewButton = true
-			buttonFrame:SetHighlightTexture("Interface\\Buttons\\ButtonHilight-Square", "ADD")
+			-- buttonFrame:SetHighlightTexture("Interface\\Buttons\\ButtonHilight-Square", "ADD")
 			buttonName:SetText("")
 			buttonIcon:SetTexture(PlusTexture)
 			buttonIcon:SetDesaturated(true)
@@ -245,7 +245,7 @@ local function SetMacroItems()
 		else
 			buttonFrame.Macro = nil
 			buttonFrame.IsNewButton = false
-			buttonFrame:SetHighlightTexture(nil)
+			-- buttonFrame:SetHighlightTexture(nil)
 			buttonName:SetText("")
 			buttonIcon:SetTexture("")
 			buttonIcon:SetDesaturated(false)
@@ -737,28 +737,28 @@ function MegaMacro_IconSearchBox_TextChanged()
 end
 
 MegaMacroLastShiftClickInsertAt = nil
-hooksecurefunc("SpellButton_OnModifiedClick", function(self)
-	-- for some reason this callback is triggered twice, this will prevent that
-	if MegaMacroSystemTime == MegaMacroLastShiftClickInsertAt then
-		return
-	end
+-- hooksecurefunc("SpellButton_OnModifiedClick", function(self)
+-- 	-- for some reason this callback is triggered twice, this will prevent that
+-- 	if MegaMacroSystemTime == MegaMacroLastShiftClickInsertAt then
+-- 		return
+-- 	end
 
-	MegaMacroLastShiftClickInsertAt = MegaMacroSystemTime
+-- 	MegaMacroLastShiftClickInsertAt = MegaMacroSystemTime
 
-	local slot = SpellBook_GetSpellBookSlot(self);
-	if ( slot > MAX_SPELLS ) then
-		return
-	end
+-- 	local slot = SpellBook_GetSpellBookSlot(self);
+-- 	if ( slot > MAX_SPELLS ) then
+-- 		return
+-- 	end
 
-	if IsModifiedClick("CHATLINK") and MegaMacro_FrameText:HasFocus() then
-		local spellName, subSpellName = GetSpellBookItemName(slot, SpellBookFrame.bookType)
+-- 	if IsModifiedClick("CHATLINK") and MegaMacro_FrameText:HasFocus() then
+-- 		local spellName, subSpellName = GetSpellBookItemName(slot, SpellBookFrame.bookType)
 
-		if spellName and not IsPassiveSpell(slot, SpellBookFrame.bookType) then
-			if subSpellName and string.len(subSpellName) > 0 then
-				MegaMacro_FrameText:Insert(spellName.."("..subSpellName..")")
-			else
-				MegaMacro_FrameText:Insert(spellName)
-			end
-		end
-	end
-end)
+-- 		if spellName and not IsPassiveSpell(slot, SpellBookFrame.bookType) then
+-- 			if subSpellName and string.len(subSpellName) > 0 then
+-- 				MegaMacro_FrameText:Insert(spellName.."("..subSpellName..")")
+-- 			else
+-- 				MegaMacro_FrameText:Insert(spellName)
+-- 			end
+-- 		end
+-- 	end
+-- end)

--- a/src/windows/mega-macro.window.xml
+++ b/src/windows/mega-macro.window.xml
@@ -1,6 +1,6 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/..\..\FrameXML\UI.xsd">
 	<Script file="src/windows/mega-macro.window.lua"/>
-	<CheckButton name="MegaMacro_ButtonTemplate" inherits="PopupButtonTemplate" virtual="true">
+	<CheckButton name="MegaMacro_ButtonTemplate" inherits="SelectorButtonTemplate" virtual="true">
 		<Scripts>
 			<OnLoad>self:RegisterForDrag("LeftButton");</OnLoad>
 			<OnClick>MegaMacro_MacroButton_OnClick(self);</OnClick>
@@ -9,6 +9,15 @@
 			<OnDragStart>MegaMacro_MacroButton_OnDragStart(self);</OnDragStart>
 			<OnReceiveDrag>MegaMacro_MacroButton_OnReceiveDrag(self);</OnReceiveDrag>
 		</Scripts>
+		<Layers>
+			<Layer level="ARTWORK">
+				<FontString name="$parentName" inherits="GameFontHighlightSmall" text="">
+					<Anchors>
+						<Anchor point="CENTER" relativeTo="$parent" x="0" y="-10"/>
+					</Anchors>
+				</FontString>
+			</Layer>
+		</Layers>
 	</CheckButton>
 	<CheckButton name="MegaMacro_PopupButtonTemplate" inherits="SimplePopupButtonTemplate" virtual="true">
 		<Scripts>
@@ -146,6 +155,16 @@
 					<OnEnter>MegaMacro_FrameSelectedMacroButton_OnEnter();</OnEnter>
 					<OnLeave>MegaMacro_FrameSelectedMacroButton_OnLeave();</OnLeave>
 				</Scripts>
+				<Layers>
+					<Layer level="ARTWORK">
+						<Texture name="MegaMacro_FrameSelectedMacroButtonIcon" file="Interface\Buttons\UI-EmptySlot">
+							<Size x="44" y="44"/>
+							<Anchors>
+								<Anchor point="CENTER" relativeTo="$parent" x="0" y="0"/>
+							</Anchors>
+						</Texture>
+					</Layer>
+				</Layers>
 			</CheckButton>
 			<ScrollFrame name="MegaMacro_ButtonScrollFrame" inherits="UIPanelScrollFrameTemplate">
 				<Size x="593" y="146"/>
@@ -308,14 +327,14 @@
 					<Anchor point="TOPLEFT" relativeTo="MegaMacro_Frame" x="6" y="-289"/>
 				</Anchors>
 			</Frame>
-			<Button name="MegaMacro_FrameTab1" inherits="TabButtonTemplate" text="Global" id="1">
+			<Button name="MegaMacro_FrameTab1" inherits="PanelTabButtonTemplate" text="Global" id="1">
 				<Anchors>
 					<Anchor point="TOPLEFT" x="51" y="-28"/>
 				</Anchors>
 				<Scripts>
 					<OnLoad>
 						PanelTemplates_TabResize(self, -8);
-						_G[self:GetName().."HighlightTexture"]:SetWidth(55);
+<!--						_G[self:GetName().."HighlightTexture"]:SetWidth(55);-->
 					</OnLoad>
 					<OnClick>
 						PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
@@ -324,14 +343,14 @@
 					<OnReceiveDrag>MegaMacro_FrameTab_OnReceiveDrag(self);</OnReceiveDrag>
 				</Scripts>
 			</Button>
-			<Button name="MegaMacro_FrameTab2" inherits="TabButtonTemplate" text="{Class}" id="2">
+			<Button name="MegaMacro_FrameTab2" inherits="PanelTabButtonTemplate" text="{Class}" id="2">
 				<Anchors>
 					<Anchor point="LEFT" relativeTo="MegaMacro_FrameTab1" relativePoint="RIGHT" x="0" y="0"/>
 				</Anchors>
 				<Scripts>
 					<OnLoad>
 						PanelTemplates_TabResize(self, 35);
-						_G[self:GetName().."HighlightTexture"]:SetWidth(103);
+<!--						_G[self:GetName().."HighlightTexture"]:SetWidth(103);-->
 					</OnLoad>
 					<OnClick>
 						PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
@@ -340,14 +359,14 @@
 					<OnReceiveDrag>MegaMacro_FrameTab_OnReceiveDrag(self);</OnReceiveDrag>
 				</Scripts>
 			</Button>
-			<Button name="MegaMacro_FrameTab3" inherits="TabButtonTemplate" text="{Spec}" id="3">
+			<Button name="MegaMacro_FrameTab3" inherits="PanelTabButtonTemplate" text="{Spec}" id="3">
 				<Anchors>
 					<Anchor point="LEFT" relativeTo="MegaMacro_FrameTab2" relativePoint="RIGHT" x="0" y="0"/>
 				</Anchors>
 				<Scripts>
 					<OnLoad>
 						PanelTemplates_TabResize(self, 20);
-						_G[self:GetName().."HighlightTexture"]:SetWidth(82);
+<!--						_G[self:GetName().."HighlightTexture"]:SetWidth(82);-->
 					</OnLoad>
 					<OnClick>
 						PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
@@ -356,14 +375,14 @@
 					<OnReceiveDrag>MegaMacro_FrameTab_OnReceiveDrag(self);</OnReceiveDrag>
 				</Scripts>
 			</Button>
-			<Button name="MegaMacro_FrameTab4" inherits="TabButtonTemplate" text="{Character}" id="4">
+			<Button name="MegaMacro_FrameTab4" inherits="PanelTabButtonTemplate" text="{Character}" id="4">
 				<Anchors>
 					<Anchor point="LEFT" relativeTo="MegaMacro_FrameTab3" relativePoint="RIGHT" x="0" y="0"/>
 				</Anchors>
 				<Scripts>
 					<OnLoad>
 						PanelTemplates_TabResize(self, 20);
-						_G[self:GetName().."HighlightTexture"]:SetWidth(112);
+<!--						_G[self:GetName().."HighlightTexture"]:SetWidth(112);-->
 					</OnLoad>
 					<OnClick>
 						PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
@@ -372,14 +391,14 @@
 					<OnReceiveDrag>MegaMacro_FrameTab_OnReceiveDrag(self);</OnReceiveDrag>
 				</Scripts>
 			</Button>
-			<Button name="MegaMacro_FrameTab5" inherits="TabButtonTemplate" text="{Character Spec}" id="5">
+			<Button name="MegaMacro_FrameTab5" inherits="PanelTabButtonTemplate" text="{Character Spec}" id="5">
 				<Anchors>
 					<Anchor point="LEFT" relativeTo="MegaMacro_FrameTab4" relativePoint="RIGHT" x="0" y="0"/>
 				</Anchors>
 				<Scripts>
 					<OnLoad>
 						PanelTemplates_TabResize(self, 60);
-						_G[self:GetName().."HighlightTexture"]:SetWidth(190);
+<!--						_G[self:GetName().."HighlightTexture"]:SetWidth(190);-->
 					</OnLoad>
 					<OnClick>
 						PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
@@ -551,7 +570,7 @@
 				</Scripts>
 				<FontString inherits="ChatFontNormal"/>
 			</EditBox>
-			<ScrollFrame name="MegaMacro_PopupScrollFrame" inherits="ListScrollFrameTemplate">
+			<ScrollFrame name="MegaMacro_PopupScrollFrame" inherits="UIPanelScrollFrameTemplate2">
 				<Size x="485" y="389"/>
 				<Anchors>
 					<Anchor point="BOTTOMRIGHT" relativeTo="MegaMacro_PopupFrame" x="-36" y="48"/>

--- a/src/windows/mega-macro.window.xml
+++ b/src/windows/mega-macro.window.xml
@@ -570,7 +570,7 @@
 				</Scripts>
 				<FontString inherits="ChatFontNormal"/>
 			</EditBox>
-			<ScrollFrame name="MegaMacro_PopupScrollFrame" inherits="UIPanelScrollFrameTemplate2">
+			<ScrollFrame name="MegaMacro_PopupScrollFrame" inherits="UIPanelScrollFrameTemplate">
 				<Size x="485" y="389"/>
 				<Anchors>
 					<Anchor point="BOTTOMRIGHT" relativeTo="MegaMacro_PopupFrame" x="-36" y="48"/>
@@ -578,6 +578,11 @@
 				<Scripts>
 					<OnVerticalScroll>FauxScrollFrame_OnVerticalScroll(self, offset, MACRO_ICON_ROW_HEIGHT, MacroPopupFrame_Update);</OnVerticalScroll>
 				</Scripts>
+				<ScrollChild>
+					<Frame name="$parentScrollChildFrame">
+						<Size x="485" y="389"/>
+					</Frame>
+				</ScrollChild>
 			</ScrollFrame>
 		</Frames>
 	</Frame>


### PR DESCRIPTION
@Sellorio 

This gets it working for Dragonflight.

Changes include: 
- fixed click event (thanks to @Dannez83)
- updated xml template inheritance (@Dannez83 again, with tweaks by me)
- some lua tweaks and 2 new xml entries to go along with the new xml inheritance
- revert a caching feature that seemed to break the non global macro pages
- fix shift clicking on spell book buttons
- fix for popup scrollbar

@Dannez83, I've made this under a new fork because yours had altered line endings that made viewing the diff very difficult. I'm not sure how to correct that so I just started over.

Related Issue: #158

*Edit: Fixed the shift click issue and a scrollbar error. Should be fully usable now.
