### PR TITLE
fix shift click registering more than once

### DIFF
--- a/src/main.lua
+++ b/src/main.lua
@@ -43,8 +43,6 @@ local function Initialize()
         MegaMacroFullyActive = MegaMacroGlobalData.Activated and MegaMacroCharacterData.Activated
         f:SetScript("OnUpdate", OnUpdate)
     end
-
-    MegaMacro_RegisterShiftClicks()
 end
 
 f:SetScript("OnEvent", function(self, event)
@@ -69,3 +67,5 @@ f:SetScript("OnEvent", function(self, event)
         MegaMacroActionBarEngine.OnTargetChanged()
     end
 end)
+
+MegaMacro_RegisterShiftClicks()


### PR DESCRIPTION
The OnModifierClick is being hooked an additional time whenever the player enters a new area. I didn't realize the initialize function was called more than just on addon load and put the hook in there. This fixes it.

Hopefully no more bugs after this >_>