### PR TITLE
quick fix for prepatch keyDown bug

### DIFF
--- a/src/engine/mega-macro-engine.lua
+++ b/src/engine/mega-macro-engine.lua
@@ -119,14 +119,15 @@ end
 
 local function GetMacroStubCode(macroId)
     -- Fix a bug that causes click events not to register only when CVar ActionButtonUseKeyDown is set to 1. 
+    local keyDownOrUp = GetCVar("ActionButtonUseKeyDown")
     local primaryMacroButtonClickValue = GetCVar("ActionButtonUseKeyDown") == "1" and " LeftButton" or " " 
     return
         GenerateIdPrefix(macroId).."\n"..
-        "/click [btn:1] "..ClickyFrameName..macroId..primaryMacroButtonClickValue.."\n"..
-        "/click [btn:2] "..ClickyFrameName..macroId.." RightButton\n"..
-        "/click [btn:3] "..ClickyFrameName..macroId.." MiddleButton\n"..
-        "/click [btn:4] "..ClickyFrameName..macroId.." Button4\n"..
-        "/click [btn:5] "..ClickyFrameName..macroId.." Button5\n"
+        "/click [btn:1] "..ClickyFrameName..macroId..primaryMacroButtonClickValue.." "..keyDownOrUp.."\n"..
+        "/click [btn:2] "..ClickyFrameName..macroId.." RightButton "..keyDownOrUp.."\n"..
+        "/click [btn:3] "..ClickyFrameName..macroId.." MiddleButton "..keyDownOrUp.."\n"..
+        "/click [btn:4] "..ClickyFrameName..macroId.." Button4 "..keyDownOrUp.."\n"..
+        "/click [btn:5] "..ClickyFrameName..macroId.." Button5 "..keyDownOrUp.."\n"
 end
 
 local function SetupGlobalMacros()


### PR DESCRIPTION
Until someone with more time and knowledge of the code can look into this I created a quick fix that gets the addon working again for people using ActionButtonUseKeyDown==1. Requires a reload if changing the CVar but I don't imagine it's something users fiddle with every day, so not a huge deal IMO.

fix #181 