### PR TITLE
Fix name overlap, fix editor scroll bug

### DIFF
--- a/src/windows/mega-macro.window.xml
+++ b/src/windows/mega-macro.window.xml
@@ -12,6 +12,7 @@
 		<Layers>
 			<Layer level="ARTWORK">
 				<FontString name="$parentName" inherits="GameFontHighlightSmall" text="">
+					<Size x="36" y="36"/>
 					<Anchors>
 						<Anchor point="CENTER" relativeTo="$parent" x="0" y="-10"/>
 					</Anchors>
@@ -228,7 +229,6 @@
 				<Scripts>
 					<OnMouseWheel>
 						ScrollFrameTemplate_OnMouseWheel(self, delta);
-						ScrollFrameTemplate_OnMouseWheel(MegaMacro_FormattedFrameScrollFrame, delta);
 					</OnMouseWheel>
 					<OnVerticalScroll>
 						local scrollbar1 = MegaMacro_FrameScrollFrameScrollBar;
@@ -276,6 +276,11 @@
 			</ScrollFrame>
 			<ScrollFrame name="MegaMacro_FormattedFrameScrollFrame" inherits="UIPanelScrollFrameTemplate">
 				<Size x="591" y="185"/>
+				<Scripts>
+					<OnMouseWheel>
+						ScrollFrameTemplate_OnMouseWheel(self, delta);
+					</OnMouseWheel>
+				</Scripts>
 				<Anchors>
 					<Anchor point="TOPLEFT" relativeTo="MegaMacro_FrameSelectedMacroBackground" relativePoint="BOTTOMLEFT" x="11" y="-13"/>
 				</Anchors>


### PR DESCRIPTION
Name overlap: Issue #180

Scroll bug: With long macro texts, scrolling was causing the highlighting text to misalign from input text.