### PR TITLE
New feature: Native Macros

### DIFF
--- a/MegaMacro.toc
+++ b/MegaMacro.toc
@@ -24,6 +24,5 @@ src/engine/parsing/conditions.lua
 src/engine/mega-macro-parser.lua
 
 src/windows/mega-macro.window.xml
-src/windows/mega-macro.window.lua
 
 src/main.lua

--- a/MegaMacro.toc
+++ b/MegaMacro.toc
@@ -1,4 +1,4 @@
-## Interface: 100200
+## Interface: 100205
 ## Title: Mega Macro
 ## Author: Sellorio
 ## Version: 1.0.0

--- a/scripts/publish.bat
+++ b/scripts/publish.bat
@@ -1,3 +1,4 @@
 CALL .\depublish.bat
 mkdir "C:\Program Files (x86)\World of Warcraft\_retail_\Interface\AddOns\MegaMacro"
 xcopy /e /i /exclude:..\.publishignore .. "C:\Program Files (x86)\World of Warcraft\_retail_\Interface\AddOns\MegaMacro"
+PAUSE

--- a/src/config.lua
+++ b/src/config.lua
@@ -19,7 +19,7 @@ function MegaMacro_InitialiseConfig()
         MegaMacroConfig = {
             UseNativeMacros = false,
             MaxMacroLength = MegaMacroCodeMaxLength,
-            UseNativeActionBarIcon = false,
+            UseNativeActionBar = false,
         }
     end
 
@@ -44,8 +44,8 @@ function MecaMacro_GenerateConfig()
         MegaMacro_BlizMacro_Toggle()
     end)
     -- Blizzard Action Bar Icons
-    MecaMacroConfig_GenerateCheckbox('UseBlizzardActionIcons', 'Blizzard Action Bar Icons', 'Disable Mega Macro Action Bar Engine. \nOnly Use with Blizzard Style Macros', 0, -25, MegaMacroConfig.UseNativeActionBarIcon, function(value) 
-        MegaMacroConfig.UseNativeActionBarIcon = value
+    MecaMacroConfig_GenerateCheckbox('UseBlizzardActionIcons', 'Blizzard Action Bar Icons', 'Disable Mega Macro Action Bar Engine. \nOnly Use with Blizzard Style Macros', 0, -25, MegaMacroConfig.UseNativeActionBar, function(value) 
+        MegaMacroConfig.UseNativeActionBar = value
     end)
 end
 

--- a/src/config.lua
+++ b/src/config.lua
@@ -14,6 +14,16 @@ function MegaMacro_InitialiseConfig()
             Specializations = {}
         }
     end
+
+    if MegaMacroConfig == nil then
+        MegaMacroConfig = {
+            UseNativeMacros = false,
+            MaxMacroLength = MegaMacroCodeMaxLength,
+            UseNativeActionBarIcon = false,
+        }
+    end
+
+    MegaMacroConfig['MaxMacroLength'] = MegaMacroConfig['UseNativeMacros'] and 250 or MegaMacroCodeMaxLength
 end
 
 function MegaMacroConfig_IsWindowDialog()

--- a/src/config.lua
+++ b/src/config.lua
@@ -35,3 +35,32 @@ function MegaMacroConfig_GetWindowPosition()
         return MegaMacroGlobalData.WindowInfo.RelativePoint, MegaMacroGlobalData.WindowInfo.X, MegaMacroGlobalData.WindowInfo.Y
     end
 end
+
+-- Create the Config options
+function MecaMacro_GenerateConfig()
+    -- Blizzard Macro option
+    MecaMacroConfig_GenerateCheckbox('UseBlizzardMacros', 'Blizzard Style Macros', '250 Char limit. \nUses Blizzards Macro Buttons while keeping MegaMacro interface and organizer. \n\nEnable this if you have stability issues or need to uninstall MegaMacro. \n\nNote: Uninstalling may still cause you to lose class and spec Macros since they are not supported by Blizzard. Move them to global or character tabs before uninstalling.', 0, 0, MegaMacroConfig.UseNativeMacros, function(value) 
+        MegaMacroConfig.UseNativeMacros = value
+        MegaMacro_BlizMacro_Toggle()
+    end)
+    -- Blizzard Action Bar Icons
+    MecaMacroConfig_GenerateCheckbox('UseBlizzardActionIcons', 'Blizzard Action Bar Icons', 'Disable Mega Macro Action Bar Engine. \nOnly Use with Blizzard Style Macros', 0, -25, MegaMacroConfig.UseNativeActionBarIcon, function(value) 
+        MegaMacroConfig.UseNativeActionBarIcon = value
+    end)
+end
+
+function MecaMacroConfig_GenerateCheckbox(name, text, tooltip, x, y, checked, onClick)
+    local checkbox = CreateFrame("CheckButton", "MegaMacro_ConfigContainer_" .. name, MegaMacro_ConfigContainer, "ChatConfigCheckButtonTemplate")
+    checkbox:SetPoint("TOPLEFT", x, y)
+    checkbox:SetChecked(checked)
+    checkbox:SetScript("OnClick", function(self)
+        onClick(checkbox:GetChecked())
+    end)
+    checkbox.tooltip = tooltip
+    
+    local textFrame = _G[checkbox:GetName() .. "Text"]
+    textFrame:SetFontObject("GameFontNormalSmall")
+    textFrame:SetText(text)
+
+    return checkbox
+end

--- a/src/engine/mega-macro-action-bar-engine.lua
+++ b/src/engine/mega-macro-action-bar-engine.lua
@@ -316,6 +316,9 @@ local function UpdateActionBar(button, macroId)
 end
 
 local function ResetActionBar(button)
+	if MegaMacroConfig['UseNativeActionBar'] then
+		return
+	end
 	button:SetChecked(false)
 	button.Count:SetText("")
 	button.Border:Hide() -- reset eqipped border

--- a/src/engine/mega-macro-action-bar-engine.lua
+++ b/src/engine/mega-macro-action-bar-engine.lua
@@ -275,6 +275,10 @@ local function UpdateRange(button, functions, abilityId, target)
 end
 
 local function UpdateActionBar(button, macroId)
+	if MegaMacroConfig['UseNativeActionBarIcon'] then
+		return
+	end
+
     local data = MegaMacroIconEvaluator.GetCachedData(macroId)
     local functions = MegaMacroInfoFunctions.Unknown
 

--- a/src/engine/mega-macro-action-bar-engine.lua
+++ b/src/engine/mega-macro-action-bar-engine.lua
@@ -275,7 +275,7 @@ local function UpdateRange(button, functions, abilityId, target)
 end
 
 local function UpdateActionBar(button, macroId)
-	if MegaMacroConfig['UseNativeActionBarIcon'] then
+	if MegaMacroConfig['UseNativeActionBar'] then
 		return
 	end
 

--- a/src/engine/mega-macro-engine.lua
+++ b/src/engine/mega-macro-engine.lua
@@ -120,7 +120,7 @@ end
 local function GetMacroStubCode(macroId)
     return
         GenerateIdPrefix(macroId).."\n"..
-        "/click [btn:1] "..ClickyFrameName..macroId.."\n"..
+        "/click [btn:1] "..ClickyFrameName..macroId.." LeftButton\n"..
         "/click [btn:2] "..ClickyFrameName..macroId.." RightButton\n"..
         "/click [btn:3] "..ClickyFrameName..macroId.." MiddleButton\n"..
         "/click [btn:4] "..ClickyFrameName..macroId.." Button4\n"..

--- a/src/engine/mega-macro-engine.lua
+++ b/src/engine/mega-macro-engine.lua
@@ -259,7 +259,7 @@ local function UnbindMacro(macro)
 
         if macroIndex then
             MegaMacroEngine.GetOrCreateClicky(macro.Id):SetAttribute("macrotext", "")
-            EditMacro(macroIndex, " ", nil, nil, true, macroIndex > MacroLimits.MaxGlobalMacros)
+            EditMacro(macroIndex, " ", nil, GenerateIdPrefix(macro.Id), true, macroIndex > MacroLimits.MaxGlobalMacros)
             InitializeMacroIndexCache()
         end
     end

--- a/src/engine/mega-macro-engine.lua
+++ b/src/engine/mega-macro-engine.lua
@@ -204,6 +204,12 @@ function MegaMacroEngine.FindAvailableGlobalMacro()
                 return i
             end
         end
+        -- Didn't find a free slot. Try to find an inactive one.
+        for i=startIndex, endIndex do
+            if usedMacroIndexes[i] and MegaMacroEngine.GetMacroIdFromIndex(i) > MacroIndexOffsets.Inactive then
+                return i
+            end
+        end
         print("Mega Macro: Failed to find available global macro slot.")
         return nil
     end

--- a/src/engine/mega-macro-engine.lua
+++ b/src/engine/mega-macro-engine.lua
@@ -182,7 +182,7 @@ local function SetupOrUpdateMacros()
                     table.insert(unassignedMacros, i)
                 else
                     assignedMacroIds[macroId] = i
-                    EditMacro(i, nil, MegaMacroTexture, GetMacroStubCode(macroId), true, isCharacterSpecificMacroIndex)
+                    -- EditMacro(i, nil, MegaMacroTexture, GetMacroStubCode(macroId), true, isCharacterSpecificMacroIndex)
                 end
             else
                 table.insert(unassignedMacros, i)
@@ -194,7 +194,8 @@ local function SetupOrUpdateMacros()
             while lastCheckedMacroId < endIndex do
                 lastCheckedMacroId = lastCheckedMacroId + 1
                 if not assignedMacroIds[lastCheckedMacroId] then
-                    EditMacro(macroIndex, nil, nil, GetMacroStubCode(lastCheckedMacroId), true, macroIndex > MacroLimits.MaxGlobalMacros)
+                    local code = GetMacroBody(macroIndex)
+                    EditMacro(macroIndex, nil, nil, GenerateIdPrefix(lastCheckedMacroId)..code, true, macroIndex > MacroLimits.MaxGlobalMacros)
                     break
                 end
             end
@@ -220,8 +221,12 @@ local function BindMacro(macro)
         local macroIndex = MacroIndexCache[macro.Id]
 
         if macroIndex then
-            GetOrCreateClicky(macro.Id):SetAttribute("macrotext", macro.Code)
-            EditMacro(macroIndex, FormatMacroDisplayName(macro.DisplayName), nil, nil, true, macroIndex > MacroLimits.MaxGlobalMacros)
+            if MegaMacroConfig['UseNativeMacros'] then
+                EditMacro(macroIndex, FormatMacroDisplayName(macro.DisplayName), nil, GenerateIdPrefix(macro.Id)..'\n'..macro.Code, true, macroIndex > MacroLimits.MaxGlobalMacros)
+            else
+                GetOrCreateClicky(macro.Id):SetAttribute("macrotext", macro.Code)
+                EditMacro(macroIndex, FormatMacroDisplayName(macro.DisplayName), nil, GetMacroStubCode(macro.Id), true, macroIndex > MacroLimits.MaxGlobalMacros)
+            end
             InitializeMacroIndexCache()
         end
     end

--- a/src/engine/mega-macro-engine.lua
+++ b/src/engine/mega-macro-engine.lua
@@ -118,9 +118,11 @@ local function TryImportCharacterMacros()
 end
 
 local function GetMacroStubCode(macroId)
+    -- Fix a bug that causes click events not to register only when CVar ActionButtonUseKeyDown is set to 1. 
+    local primaryMacroButtonClickValue = GetCVar("ActionButtonUseKeyDown") == "1" and " LeftButton" or " " 
     return
         GenerateIdPrefix(macroId).."\n"..
-        "/click [btn:1] "..ClickyFrameName..macroId.." LeftButton\n"..
+        "/click [btn:1] "..ClickyFrameName..macroId..primaryMacroButtonClickValue.."\n"..
         "/click [btn:2] "..ClickyFrameName..macroId.." RightButton\n"..
         "/click [btn:3] "..ClickyFrameName..macroId.." MiddleButton\n"..
         "/click [btn:4] "..ClickyFrameName..macroId.." Button4\n"..

--- a/src/engine/mega-macro-engine.lua
+++ b/src/engine/mega-macro-engine.lua
@@ -59,7 +59,7 @@ local function BindMacro(macro, macroIndex)
         -- Find a free slot. Need to know if global or character
         local isGlobal = macro.Scope == MegaMacroScopes.Global or macro.Scope == MegaMacroScopes.Class or macro.Scope == MegaMacroScopes.Specialization
         macroIndex = isGlobal and MegaMacroEngine.FindAvailableGlobalMacro() or MegaMacroEngine.FindAvailableCharacterMacro()
-        print("Mega Macro: Found available macro slot for " .. macro.DisplayName .. " at " .. macroIndex)
+        -- print("Mega Macro: Found available macro slot for " .. macro.DisplayName .. " at " .. macroIndex)
     end
     -- Bind code to macro
     if macroIndex then
@@ -71,7 +71,7 @@ local function BindMacro(macro, macroIndex)
         end
         InitializeMacroIndexCache()
     else
-        print("Mega Macro: Failed to bind macro " .. macro.DisplayName .. ". " .. macroIndex .. " is not a valid index.")
+        print("Mega Macro: Failed to bind macro " .. macro.DisplayName .. ".")
     end
 end
 
@@ -111,7 +111,6 @@ local function TryImportCharacterMacros()
         local name, _, body, _ = GetMacroInfo(i)
         -- First, is it already a Mega Macro?
         local macroId = GetIdFromMacroCode(body)
-        -- print(i, name, body, macroId)
 
         if not macroId then
             local macro = MegaMacro.Create(name, MegaMacroScopes.Character, MegaMacroTexture)

--- a/src/engine/mega-macro-engine.lua
+++ b/src/engine/mega-macro-engine.lua
@@ -23,30 +23,26 @@ end
 local function InitializeMacroIndexCache()
     MacroIndexCache = {}
 
-    if MegaMacroGlobalData.Activated then
-        for i=1, MacroLimits.MaxGlobalMacros do
-            local macroCode = GetMacroBody(i)
+    for i=1, MacroLimits.MaxGlobalMacros do
+        local macroCode = GetMacroBody(i)
 
-            if macroCode then
-                local macroId = GetIdFromMacroCode(macroCode)
+        if macroCode then
+            local macroId = GetIdFromMacroCode(macroCode)
 
-                if macroId then
-                    MacroIndexCache[macroId] = i
-                end
+            if macroId then
+                MacroIndexCache[macroId] = i
             end
         end
     end
 
-    if MegaMacroCharacterData.Activated then
-        for i=1 + MacroLimits.MaxGlobalMacros, MacroLimits.MaxGlobalMacros + MacroLimits.MaxCharacterMacros do
-            local macroCode = GetMacroBody(i)
+    for i=1 + MacroLimits.MaxGlobalMacros, MacroLimits.MaxGlobalMacros + MacroLimits.MaxCharacterMacros do
+        local macroCode = GetMacroBody(i)
 
-            if macroCode then
-                local macroId = GetIdFromMacroCode(macroCode)
+        if macroCode then
+            local macroId = GetIdFromMacroCode(macroCode)
 
-                if macroId then
-                    MacroIndexCache[macroId] = i
-                end
+            if macroId then
+                MacroIndexCache[macroId] = i
             end
         end
     end

--- a/src/engine/mega-macro-engine.lua
+++ b/src/engine/mega-macro-engine.lua
@@ -52,6 +52,19 @@ local function InitializeMacroIndexCache()
     end
 end
 
+local function GenerateNativeMacroCode(macro)
+    -- Check if there is #showtooltip already. If not, add it to the start.
+    local code = macro.Code
+    if #code <= MegaMacroCodeMaxLengthForNative - 14 then
+        if not string.find(code, "#showtooltip") then
+            code = "#showtooltip\n" .. code
+        end
+    end
+    code = GenerateIdPrefix(macro.Id) .. "\n" .. code
+    return code
+end
+
+
 local function BindMacro(macro, macroIndex)
     local macroIndex = macroIndex or MacroIndexCache[macro.Id]
 
@@ -64,7 +77,7 @@ local function BindMacro(macro, macroIndex)
     -- Bind code to macro
     if macroIndex then
         if #macro.Code <= MegaMacroCodeMaxLengthForNative then
-            EditMacro(macroIndex, FormatMacroDisplayName(macro.DisplayName), nil, GenerateIdPrefix(macro.Id).."\n"..macro.Code, true, macroIndex > MacroLimits.MaxGlobalMacros)
+            EditMacro(macroIndex, FormatMacroDisplayName(macro.DisplayName), nil, GenerateNativeMacroCode(macro), true, macroIndex > MacroLimits.MaxGlobalMacros)
         else
             MegaMacroEngine.GetOrCreateClicky(macro.Id):SetAttribute("macrotext", macro.Code)
             EditMacro(macroIndex, FormatMacroDisplayName(macro.DisplayName), nil, MegaMacroEngine.GetMacroStubCode(macro.Id), true, macroIndex > MacroLimits.MaxGlobalMacros)

--- a/src/engine/mega-macro-engine.lua
+++ b/src/engine/mega-macro-engine.lua
@@ -95,15 +95,15 @@ local function TryImportGlobalMacros()
     local numberOfGlobalMacros = GetNumMacros()
 
     for i=1, numberOfGlobalMacros do
-        local name, _, body, _ = GetMacroInfo(i)
+        local name, iconTexture, body, _ = GetMacroInfo(i)
         -- First, is it already a Mega Macro?
         local macroId = GetIdFromMacroCode(body)
         
         if not macroId then
-            local macro = MegaMacro.Create(name, MegaMacroScopes.Global, MegaMacroTexture, nil, body, i)
+            local macro = MegaMacro.Create(name, MegaMacroScopes.Global, iconTexture or MegaMacroTexture, true, body, i)
 
             if macro == nil then
-                macro = MegaMacro.Create(name, MegaMacroScopes.Inactive, MegaMacroTexture, nil, body, i)
+                macro = MegaMacro.Create(name, MegaMacroScopes.Inactive, iconTexture or MegaMacroTexture, true, body, i)
                 if macro == nil then
                     return false, "Failed to import at macro " .. i .. "(" .. name .. "). Please delete the macro and reload your UI."
                 end
@@ -123,15 +123,15 @@ local function TryImportCharacterMacros()
     local _, numberOfCharacterMacros = GetNumMacros()
 
     for i=1 + MacroIndexOffsets.NativeCharacterMacros, numberOfCharacterMacros + MacroIndexOffsets.NativeCharacterMacros do
-        local name, _, body, _ = GetMacroInfo(i)
+        local name, iconTexture, body, _ = GetMacroInfo(i)
         -- First, is it already a Mega Macro?
         local macroId = GetIdFromMacroCode(body)
 
         if not macroId then
-            local macro = MegaMacro.Create(name, MegaMacroScopes.Character, MegaMacroTexture, nil, body, i)
+            local macro = MegaMacro.Create(name, MegaMacroScopes.Character, iconTexture or MegaMacroTexture, true, body, i)
 
             if macro == nil then
-                macro = MegaMacro.Create(name, MegaMacroScopes.Inactive, MegaMacroTexture, nil, body, i)
+                macro = MegaMacro.Create(name, MegaMacroScopes.Inactive, iconTexture or MegaMacroTexture, true, body, i)
                 if macro == nil then
                     return false, "Failed to import at macro " .. i .. "(" .. name .. "). Please delete the macro and reload your UI."
                 end
@@ -374,6 +374,7 @@ function MegaMacroEngine.VerifyMacros()
         end
     end
 
+    InitializeMacroIndexCache()
     -- Verify that every macro in the addon is in the macro index cache. If not, we need to make a new macro. Also check duplicates
     local macroIds = {}
     local function VerifyMacro(macro, i)

--- a/src/engine/mega-macro-icon-evaluator.lua
+++ b/src/engine/mega-macro-icon-evaluator.lua
@@ -236,7 +236,7 @@ local function UpdateMacro(macro)
         end
     end
 
-    if MegaMacroConfig['UseNativeActionBar'] or true then
+    if MegaMacroConfig['UseNativeActionBar'] then
 		return
 	end
 

--- a/src/engine/mega-macro-icon-evaluator.lua
+++ b/src/engine/mega-macro-icon-evaluator.lua
@@ -126,8 +126,12 @@ local function ComputeMacroIcon(macro, staticTexture, isStaticTextureFallback)
 
                 if ability ~= nil then
                     effectType, effectId, effectName, icon = GetAbilityData(ability)
-                    target = tar
-                    break
+
+                    -- skip spells or items that do not exist
+                    if effectType ~= "unknown" then
+                        target = tar
+                        break
+                    end
                 end
             elseif command.Type == "castsequence" then
                 local sequenceCode, tar = SecureCmdOptionParse(command.Body)

--- a/src/engine/mega-macro-icon-evaluator.lua
+++ b/src/engine/mega-macro-icon-evaluator.lua
@@ -236,6 +236,10 @@ local function UpdateMacro(macro)
         end
     end
 
+    if MegaMacroConfig['UseNativeActionBar'] or true then
+		return
+	end
+
     local macroIndex = MegaMacroEngine.GetMacroIndexFromId(macro.Id)
     if macroIndex and not InCombatLockdown() then
         if effectType == "spell" then

--- a/src/engine/parsing/conditions.lua
+++ b/src/engine/parsing/conditions.lua
@@ -89,6 +89,24 @@ local function NumberModifier(parsingContext)
     return "", false
 end
 
+local function MultiNumberModifier(parsingContext)
+    local hasModifier = IsModifierSeparator(parsingContext)
+    if hasModifier then
+        local word = GetWord(parsingContext, 1)
+        local wordLength = #word
+
+        -- Check for a single number or a sequence of numbers separated by slashes
+        if word:match("^%d+$") or word:match("%d+(/%d+)$") then
+            local result = ParseResult(parsingContext, 1, Colours.Syntax)..ParseResult(parsingContext, wordLength, Colours.Number)
+            return result, true
+        else
+            return "", false
+        end
+    end
+
+    return "", false
+end
+
 local function OptionalWordModifier(parsingContext)
     local hasModifier = IsModifierSeparator(parsingContext)
 
@@ -221,7 +239,7 @@ local function KnownModifier(parsingContext)
                     break
                 end
             end
-            if separator ~= "]" then
+            if separator ~= "]" and separator ~= "," then
                 spell = spell .. separator
             end
         end
@@ -260,7 +278,7 @@ local Conditionals = {
 	extrabar = NumberModifier,
 	flyable = NoModifier,
 	flying = NoModifier,
-	form = NumberModifier,
+	form = MultiNumberModifier,
 	group = GroupModifier,
 	harm = NoModifier,
 	help = NoModifier,
@@ -278,7 +296,7 @@ local Conditionals = {
 	pvptalent = TalentModifier,
 	raid = NoModifier,
 	spec = NumberModifier,
-	stance = NumberModifier,
+	stance = MultiNumberModifier,
 	stealth = NoModifier,
 	swimming = NoModifier,
 	talent = TalentModifier,

--- a/src/engine/parsing/parsing-functions.lua
+++ b/src/engine/parsing/parsing-functions.lua
@@ -8,7 +8,7 @@ local function GetWord(parsingContext, offset)
     local index = parsingContext.Index + (offset or 0)
     local text = ""
     local character = GetCharacter({ Code = parsingContext.Code, Index = index })
-    while character and (string.match(character, "[a-z]") or string.match(character, "[A-Z]") or string.match(character, "[0-9]") or character == "_") do
+    while character and (string.match(character, "[a-z]") or string.match(character, "[A-Z]") or string.match(character, "[0-9]") or character == "_" or character == "/") do
         text = text..character
         index = index + 1
         character = GetCharacter({ Code = parsingContext.Code, Index = index })

--- a/src/main.lua
+++ b/src/main.lua
@@ -1,5 +1,4 @@
 MegaMacroCachedClass = nil
-MegaMacroCachedClassFull = nil
 MegaMacroCachedSpecialization = nil
 MegaMacroFullyActive = false
 MegaMacroSystemTime = GetTime()
@@ -34,7 +33,7 @@ local function Initialize()
 
     local specIndex = GetSpecialization()
     if specIndex then
-        MegaMacroCachedClassFull, MegaMacroCachedClass = UnitClass("player")
+        MegaMacroCachedClass = UnitClass("player")
         MegaMacroCachedSpecialization = select(2, GetSpecializationInfo(specIndex))
 
         MegaMacroCodeInfo.ClearAll()

--- a/src/main.lua
+++ b/src/main.lua
@@ -42,8 +42,8 @@ local function Initialize()
         MegaMacroCodeInfo.ClearAll()
         MegaMacroIconEvaluator.Initialize()
         MegaMacroActionBarEngine.Initialize()
-        MegaMacroEngine.ImportMacros()
         MegaMacroEngine.SafeInitialize()
+        MegaMacroEngine.ImportMacros()
         MegaMacroFullyActive = MegaMacroGlobalData.Activated and MegaMacroCharacterData.Activated
         f:SetScript("OnUpdate", OnUpdate)
     end

--- a/src/main.lua
+++ b/src/main.lua
@@ -12,9 +12,12 @@ f:RegisterEvent("PLAYER_TARGET_CHANGED")
 local function OnUpdate(_, elapsed)
     MegaMacroSystemTime = GetTime()
     local elapsedMs = elapsed * 1000
+    MegaMacroIconNavigator.OnUpdate()
+    if MegaMacroConfig['UseNativeActionBar'] then
+		return
+	end
     MegaMacroIconEvaluator.Update(elapsedMs)
     MegaMacroActionBarEngine.OnUpdate(elapsed)
-    MegaMacroIconNavigator.OnUpdate()
 end
 
 local function Initialize()

--- a/src/main.lua
+++ b/src/main.lua
@@ -43,8 +43,6 @@ local function Initialize()
         MegaMacroFullyActive = MegaMacroGlobalData.Activated and MegaMacroCharacterData.Activated
         f:SetScript("OnUpdate", OnUpdate)
     end
-
-    MegaMacro_RegisterShiftClicks()
 end
 
 f:SetScript("OnEvent", function(self, event)
@@ -69,3 +67,5 @@ f:SetScript("OnEvent", function(self, event)
         MegaMacroActionBarEngine.OnTargetChanged()
     end
 end)
+
+MegaMacro_RegisterShiftClicks()

--- a/src/main.lua
+++ b/src/main.lua
@@ -13,7 +13,7 @@ local function OnUpdate(_, elapsed)
     MegaMacroSystemTime = GetTime()
     local elapsedMs = elapsed * 1000
     MegaMacroIconNavigator.OnUpdate()
-    if MegaMacroConfig['UseNativeActionBar'] then
+    if MegaMacroConfig['UseNativeActionBar'] and not MegaMacro_Frame:IsVisible() then
 		return
 	end
     MegaMacroIconEvaluator.Update(elapsedMs)

--- a/src/main.lua
+++ b/src/main.lua
@@ -43,6 +43,8 @@ local function Initialize()
         MegaMacroFullyActive = MegaMacroGlobalData.Activated and MegaMacroCharacterData.Activated
         f:SetScript("OnUpdate", OnUpdate)
     end
+
+    MegaMacro_RegisterShiftClicks()
 end
 
 f:SetScript("OnEvent", function(self, event)

--- a/src/main.lua
+++ b/src/main.lua
@@ -44,6 +44,7 @@ local function Initialize()
         MegaMacroActionBarEngine.Initialize()
         MegaMacroEngine.SafeInitialize()
         MegaMacroEngine.ImportMacros()
+        MegaMacroEngine.VerifyMacros()
         MegaMacroFullyActive = MegaMacroGlobalData.Activated and MegaMacroCharacterData.Activated
         f:SetScript("OnUpdate", OnUpdate)
     end

--- a/src/mega-macro.lua
+++ b/src/mega-macro.lua
@@ -31,6 +31,7 @@ local function GetNextAvailableMacroId(startOffset, count, existingMacros)
 end
 
 MegaMacro = {}
+MegaMacro.GetNextAvailableMacroId = GetNextAvailableMacroId
 
 function MegaMacro.Create(displayName, scope, staticTexture, isStaticTextureFallback, code, macroIndex)
     local result = {}

--- a/src/mega-macro.lua
+++ b/src/mega-macro.lua
@@ -32,7 +32,7 @@ end
 
 MegaMacro = {}
 
-function MegaMacro.Create(displayName, scope, staticTexture, isStaticTextureFallback)
+function MegaMacro.Create(displayName, scope, staticTexture, isStaticTextureFallback, code, macroIndex)
     local result = {}
 
     local id
@@ -125,11 +125,11 @@ function MegaMacro.Create(displayName, scope, staticTexture, isStaticTextureFall
     result.Scope = scope
     result.ScopedIndex = scopedIndex
     result.DisplayName = displayName
-    result.Code = ""
+    result.Code = code or ""
     result.StaticTexture = staticTexture
     result.IsStaticTextureFallback = isStaticTextureFallback
 
-    MegaMacroEngine.OnMacroCreated(result)
+    MegaMacroEngine.OnMacroCreated(result, macroIndex)
 
     return result
 end

--- a/src/tooltip-functions.lua
+++ b/src/tooltip-functions.lua
@@ -14,7 +14,7 @@ function ShowToolTipForMegaMacro(macroId)
 			GameTooltip:SetEquipmentSet(data.Name)
 		else
 			local megaMacro = MegaMacro.GetById(macroId)
-			GameTooltip:SetText(megaMacro.DisplayName, 1, 1, 1)
+			GameTooltip:SetText(megaMacro.DisplayName or "", 1, 1, 1)
 		end
 
 		GameTooltip:Show()

--- a/src/windows/mega-macro.window.lua
+++ b/src/windows/mega-macro.window.lua
@@ -18,6 +18,7 @@ local PopupMode = nil
 local IconListInitialized = false
 local SelectedIcon = nil
 local IconList = {}
+local SelectedTabIndex = 1
 
 NUM_ICONS_PER_ROW = 10
 NUM_ICON_ROWS = 9
@@ -305,6 +306,13 @@ end
 
 local function PickupMegaMacro(macro)
 	local macroIndex = MegaMacroEngine.GetMacroIndexFromId(macro.Id)
+	-- highlight all tabs to indicate it can be moved to a tab
+	for i=1, 5 do
+		if i ~= SelectedTabIndex then
+			local tab = _G["MegaMacro_FrameTab"..i]
+			tab:LockHighlight()
+		end
+	end
 
 	if macroIndex then
 		PickupMacro(macroIndex)
@@ -486,18 +494,16 @@ function MegaMacro_FrameTab_OnClick(self)
 	if not HandleReceiveDrag(scope) then
 		PanelTemplates_SetTab(MegaMacro_Frame, tabIndex);
 		MegaMacro_ButtonScrollFrame:SetVerticalScroll(0)
-		MegaMacro_MoveHintText:Hide()
 		MegaMacro_ConfigContainer:Hide()
 		
 		if tabIndex == 6 then
 			SelectedScope = 'config'
 			MegaMacro_FrameTab_ShowConfig()
 			return
-		elseif tabIndex == 5 then
-			MegaMacro_MoveHintText:Show()
 		end
 		
 		SelectedScope = scope
+		SelectedTabIndex = tabIndex
 
 		InitializeMacroSlots()
 		SetMacroItems()
@@ -564,6 +570,13 @@ end
 function MegaMacro_MacroButton_OnDragStart(self)
 	if self.Macro then
 		PickupMegaMacro(self.Macro)
+	end
+end
+
+function MegaMacro_MacroButton_OnDragStop(self)
+	for i=1, 5 do
+		local tab = _G["MegaMacro_FrameTab"..i]
+		tab:UnlockHighlight()
 	end
 end
 

--- a/src/windows/mega-macro.window.lua
+++ b/src/windows/mega-macro.window.lua
@@ -736,29 +736,32 @@ function MegaMacro_IconSearchBox_TextChanged()
 	UpdateIconList()
 end
 
-MegaMacroLastShiftClickInsertAt = nil
--- hooksecurefunc("SpellButton_OnModifiedClick", function(self)
--- 	-- for some reason this callback is triggered twice, this will prevent that
--- 	if MegaMacroSystemTime == MegaMacroLastShiftClickInsertAt then
--- 		return
--- 	end
+function MegaMacro_RegisterShiftClicks()
+	function shiftClickHookFunction(self) 
+		local slot = SpellBook_GetSpellBookSlot(self);
+		if ( slot > MAX_SPELLS ) then
+			return
+		end
+	
+		if IsModifiedClick("CHATLINK") and MegaMacro_FrameText:HasFocus() then
+			local spellName, subSpellName = GetSpellBookItemName(slot, SpellBookFrame.bookType)
+	
+			if spellName and not IsPassiveSpell(slot, SpellBookFrame.bookType) then
+				if subSpellName and string.len(subSpellName) > 0 then
+					MegaMacro_FrameText:Insert(spellName.."("..subSpellName..")")
+				else
+					MegaMacro_FrameText:Insert(spellName)
+				end
+			end
+		end
+	end
+	
+	-- This is a kind of a hack, but it gets the shift click to work. We loop through all the spellbook buttons and hook their OnClick functions individually, since the generic SpellButton_OnModifiedClick was removed.
+	for i = 1, 120 do
+		local buttonName = "SpellButton" .. i
+		if _G[buttonName] ~= nil then
+			hooksecurefunc(_G[buttonName], "OnModifiedClick", shiftClickHookFunction)
+		end
+	end
+end
 
--- 	MegaMacroLastShiftClickInsertAt = MegaMacroSystemTime
-
--- 	local slot = SpellBook_GetSpellBookSlot(self);
--- 	if ( slot > MAX_SPELLS ) then
--- 		return
--- 	end
-
--- 	if IsModifiedClick("CHATLINK") and MegaMacro_FrameText:HasFocus() then
--- 		local spellName, subSpellName = GetSpellBookItemName(slot, SpellBookFrame.bookType)
-
--- 		if spellName and not IsPassiveSpell(slot, SpellBookFrame.bookType) then
--- 			if subSpellName and string.len(subSpellName) > 0 then
--- 				MegaMacro_FrameText:Insert(spellName.."("..subSpellName..")")
--- 			else
--- 				MegaMacro_FrameText:Insert(spellName)
--- 			end
--- 		end
--- 	end
--- end)

--- a/src/windows/mega-macro.window.lua
+++ b/src/windows/mega-macro.window.lua
@@ -41,7 +41,7 @@ end
 
 local function GetMacroButtonUI(index)
 	local buttonName = "MegaMacro_MacroButton" .. index
-	return _G[buttonName], _G[buttonName .. "Name"], _G[buttonName].Icon
+	return _G[buttonName], _G[buttonName].Name, _G[buttonName].Icon
 end
 
 -- Creates the button frames for the macro slots
@@ -225,6 +225,7 @@ local function SetMacroItems()
 			buttonFrame.IsNewButton = false
 			-- buttonFrame:SetHighlightTexture("Interface\\Buttons\\ButtonHilight-Square", "ADD")
 			buttonName:SetText(macro.DisplayName)
+			MegaMacroIconEvaluator.UpdateMacro(macro)
 			local data = MegaMacroIconEvaluator.GetCachedData(macro.Id)
 			buttonIcon:SetTexture(data and data.Icon or MegaMacroTexture)
 			buttonIcon:SetDesaturated(false)
@@ -481,13 +482,15 @@ function MegaMacro_FrameTab_OnClick(self)
 	if not HandleReceiveDrag(scope) then
 		PanelTemplates_SetTab(MegaMacro_Frame, tabIndex);
 		MegaMacro_ButtonScrollFrame:SetVerticalScroll(0)
+		MegaMacro_MoveHintText:Hide()
+		MegaMacro_ConfigContainer:Hide()
 		
 		if tabIndex == 6 then
 			SelectedScope = 'config'
 			MegaMacro_FrameTab_ShowConfig()
 			return
-		else
-			MegaMacro_ConfigContainer:Hide()
+		elseif tabIndex == 5 then
+			MegaMacro_MoveHintText:Show()
 		end
 		
 		SelectedScope = scope

--- a/src/windows/mega-macro.window.lua
+++ b/src/windows/mega-macro.window.lua
@@ -502,16 +502,17 @@ function MegaMacro_FrameTab_OnClick(self)
 end
 
 function MegaMacro_FrameTab_ShowConfig()
+	-- Initialize Config Options
+	if not MegaMacro_ConfigContainer.initialized then
+		MecaMacro_GenerateConfig()
+		MegaMacro_ConfigContainer.initialized = true
+	end
+
 	--Clear macro area
 	InitializeMacroSlots()
 	SelectMacro(nil)
 
-	--Set config values
-	MegaMacro_BlizMacroCheckbox:SetChecked(MegaMacroConfig["UseNativeMacros"])
-	MegaMacro_BlizActionIconCheckbox:SetChecked(MegaMacroConfig["UseNativeActionBarIcon"])
-
 	MegaMacro_ConfigContainer:Show()
-	MegaMacro_ButtonContainer:Show()
 end
 
 function MegaMacro_FrameTab_OnReceiveDrag(self)
@@ -646,18 +647,10 @@ function MegaMacro_EditButton_OnClick()
 	end
 end
 
-function MegaMacro_BlizActionIconCheckbox_OnClick()
-	-- Toggle setting and checkbox
-	MegaMacroConfig["UseNativeActionBarIcon"] = not MegaMacroConfig["UseNativeActionBarIcon"]
-	MegaMacro_BlizActionIconCheckbox:SetChecked(MegaMacroConfig["UseNativeActionBarIcon"])
-end
-
-function MegaMacro_BlizMacroCheckbox_OnClick()
-	-- Toggle setting and checkbox
-	MegaMacroConfig["UseNativeMacros"] = not MegaMacroConfig["UseNativeMacros"]
-	MegaMacro_BlizMacroCheckbox:SetChecked(MegaMacroConfig["UseNativeMacros"])
-	-- initialize macros
+function MegaMacro_BlizMacro_Toggle()
+	-- re-initialize macros
 	MegaMacroEngine.SafeInitialize()
+	-- update macro char length limit
 	MegaMacro_InitialiseConfig()
 	MegaMacro_FrameCharLimitText:SetFormattedText(
 		rendering.CharLimitMessageFormat,

--- a/src/windows/mega-macro.window.lua
+++ b/src/windows/mega-macro.window.lua
@@ -231,6 +231,10 @@ local function SetMacroItems()
 			buttonIcon:SetDesaturated(false)
 			buttonIcon:SetTexCoord(0, 1, 0, 1)
 			buttonIcon:SetAlpha(1)
+			if not MegaMacroEngine.GetMacroIndexFromId(macro.Id) then
+				buttonIcon:SetAlpha(0.5)
+				buttonIcon:SetDesaturated(true)
+			end
 		elseif not newMacroButtonCreated then
 			buttonFrame.Macro = nil
 			buttonFrame.IsNewButton = true

--- a/src/windows/mega-macro.window.lua
+++ b/src/windows/mega-macro.window.lua
@@ -41,7 +41,7 @@ end
 
 local function GetMacroButtonUI(index)
 	local buttonName = "MegaMacro_MacroButton" .. index
-	return _G[buttonName], _G[buttonName .. "Name"], _G[buttonName .. "Icon"]
+	return _G[buttonName], _G[buttonName .. "Name"], _G[buttonName].Icon
 end
 
 -- Creates the button frames for the macro slots
@@ -87,7 +87,7 @@ end
 
 local function InitializeTabs()
 	local playerName = UnitName("player")
-	MegaMacro_FrameTab2:SetText(MegaMacroCachedClassFull)
+	MegaMacro_FrameTab2:SetText(MegaMacroCachedClass)
 	MegaMacro_FrameTab4:SetText(playerName)
 
 	if MegaMacroCachedSpecialization == '' then
@@ -225,7 +225,7 @@ local function SetMacroItems()
 		if macro then
 			buttonFrame.Macro = macro
 			buttonFrame.IsNewButton = false
-			buttonFrame:SetHighlightTexture("Interface\\Buttons\\ButtonHilight-Square", "ADD")
+			-- buttonFrame:SetHighlightTexture("Interface\\Buttons\\ButtonHilight-Square", "ADD")
 			buttonName:SetText(macro.DisplayName)
 			local data = MegaMacroIconEvaluator.GetCachedData(macro.Id)
 			buttonIcon:SetTexture(data and data.Icon)
@@ -235,7 +235,7 @@ local function SetMacroItems()
 		elseif not newMacroButtonCreated then
 			buttonFrame.Macro = nil
 			buttonFrame.IsNewButton = true
-			buttonFrame:SetHighlightTexture("Interface\\Buttons\\ButtonHilight-Square", "ADD")
+			-- buttonFrame:SetHighlightTexture("Interface\\Buttons\\ButtonHilight-Square", "ADD")
 			buttonName:SetText("")
 			buttonIcon:SetTexture(PlusTexture)
 			buttonIcon:SetDesaturated(true)
@@ -245,7 +245,7 @@ local function SetMacroItems()
 		else
 			buttonFrame.Macro = nil
 			buttonFrame.IsNewButton = false
-			buttonFrame:SetHighlightTexture(nil)
+			-- buttonFrame:SetHighlightTexture(nil)
 			buttonName:SetText("")
 			buttonIcon:SetTexture("")
 			buttonIcon:SetDesaturated(false)
@@ -737,28 +737,28 @@ function MegaMacro_IconSearchBox_TextChanged()
 end
 
 MegaMacroLastShiftClickInsertAt = nil
-hooksecurefunc("SpellButton_OnModifiedClick", function(self)
-	-- for some reason this callback is triggered twice, this will prevent that
-	if MegaMacroSystemTime == MegaMacroLastShiftClickInsertAt then
-		return
-	end
+-- hooksecurefunc("SpellButton_OnModifiedClick", function(self)
+-- 	-- for some reason this callback is triggered twice, this will prevent that
+-- 	if MegaMacroSystemTime == MegaMacroLastShiftClickInsertAt then
+-- 		return
+-- 	end
 
-	MegaMacroLastShiftClickInsertAt = MegaMacroSystemTime
+-- 	MegaMacroLastShiftClickInsertAt = MegaMacroSystemTime
 
-	local slot = SpellBook_GetSpellBookSlot(self);
-	if ( slot > MAX_SPELLS ) then
-		return
-	end
+-- 	local slot = SpellBook_GetSpellBookSlot(self);
+-- 	if ( slot > MAX_SPELLS ) then
+-- 		return
+-- 	end
 
-	if IsModifiedClick("CHATLINK") and MegaMacro_FrameText:HasFocus() then
-		local spellName, subSpellName = GetSpellBookItemName(slot, SpellBookFrame.bookType)
+-- 	if IsModifiedClick("CHATLINK") and MegaMacro_FrameText:HasFocus() then
+-- 		local spellName, subSpellName = GetSpellBookItemName(slot, SpellBookFrame.bookType)
 
-		if spellName and not IsPassiveSpell(slot, SpellBookFrame.bookType) then
-			if subSpellName and string.len(subSpellName) > 0 then
-				MegaMacro_FrameText:Insert(spellName.."("..subSpellName..")")
-			else
-				MegaMacro_FrameText:Insert(spellName)
-			end
-		end
-	end
-end)
+-- 		if spellName and not IsPassiveSpell(slot, SpellBookFrame.bookType) then
+-- 			if subSpellName and string.len(subSpellName) > 0 then
+-- 				MegaMacro_FrameText:Insert(spellName.."("..subSpellName..")")
+-- 			else
+-- 				MegaMacro_FrameText:Insert(spellName)
+-- 			end
+-- 		end
+-- 	end
+-- end)

--- a/src/windows/mega-macro.window.lua
+++ b/src/windows/mega-macro.window.lua
@@ -210,7 +210,7 @@ local function SetMacroItems()
 	table.sort(
 		MacroItems,
 		function(left, right)
-			return left.DisplayName < right.DisplayName
+			return (left.DisplayName or "") < (right.DisplayName or "")
 		end)
 
 	local newMacroButtonCreated = false

--- a/src/windows/mega-macro.window.lua
+++ b/src/windows/mega-macro.window.lua
@@ -609,6 +609,22 @@ function MegaMacro_TextBox_TextChanged(self)
 		rendering.CharLimitMessageFormat,
 		MegaMacro_FrameText:GetNumLetters(),
 		MegaMacroCodeMaxLength)
+	-- Set color of text based on length
+	if MegaMacro_FrameText:GetNumLetters() > MegaMacroCodeMaxLengthForNative then
+		MegaMacro_FrameCharLimitText:SetTextColor(1, 0.85, 0)
+	else
+		MegaMacro_FrameCharLimitText:SetTextColor(1,1,1) --0.2, 0.867, 1.0
+	end
+	-- Limit. Custom hover tooltip
+	MegaMacro_FrameCharLimitText:SetScript("OnEnter", function(self)
+		GameTooltip:SetOwner(self, "ANCHOR_TOPLEFT")
+		GameTooltip:AddLine("MegaMacro: Character Limit", 1, 1, 1)
+		GameTooltip:AddLine("\nMacros over 250 characters rely on custom macro logic. They will not have a dynamic icon if you are not using MegaMacros icon rendering. This option can be set in the config tab.", 1, 1, 1, true)
+		GameTooltip:Show()
+	end)
+	MegaMacro_FrameCharLimitText:SetScript("OnLeave", function(self)
+		GameTooltip:Hide()
+	end)
 
 	ScrollingEdit_OnTextChanged(self, self:GetParent())
 	ScrollingEdit_OnTextChanged(MegaMacro_FormattedFrameText, MegaMacro_FormattedFrameText:GetParent())

--- a/src/windows/mega-macro.window.lua
+++ b/src/windows/mega-macro.window.lua
@@ -236,7 +236,7 @@ local function SetMacroItems()
 				buttonIcon:SetAlpha(0.5)
 				buttonIcon:SetDesaturated(true)
 			end
-		elseif not newMacroButtonCreated then
+		elseif not newMacroButtonCreated and SelectedScope ~= MegaMacroScopes.Inactive then
 			buttonFrame.Macro = nil
 			buttonFrame.IsNewButton = true
 			-- buttonFrame:SetHighlightTexture("Interface\\Buttons\\ButtonHilight-Square", "ADD")

--- a/src/windows/mega-macro.window.lua
+++ b/src/windows/mega-macro.window.lua
@@ -448,7 +448,7 @@ end
 
 function MegaMacro_Window_OnLoad()
     -- Global, Class, ClassSpec, Character, CharacterSpec
-	PanelTemplates_SetNumTabs(MegaMacro_Frame, 5)
+	PanelTemplates_SetNumTabs(MegaMacro_Frame, 6)
 	PanelTemplates_SetTab(MegaMacro_Frame, 1)
 	MegaMacroIconEvaluator.OnIconUpdated(function(macroId, texture)
 		MegaMacro_OnIconUpdated(macroId, texture)
@@ -483,13 +483,35 @@ function MegaMacro_FrameTab_OnClick(self)
 	if not HandleReceiveDrag(scope) then
 		PanelTemplates_SetTab(MegaMacro_Frame, tabIndex);
 		MegaMacro_ButtonScrollFrame:SetVerticalScroll(0)
-
+		
+		if tabIndex == 6 then
+			SelectedScope = 'config'
+			MegaMacro_FrameTab_ShowConfig()
+			return
+		else
+			MegaMacro_ConfigContainer:Hide()
+		end
+		
 		SelectedScope = scope
 
 		InitializeMacroSlots()
 		SetMacroItems()
 		InitializeTabs()
+
 	end
+end
+
+function MegaMacro_FrameTab_ShowConfig()
+	--Clear macro area
+	InitializeMacroSlots()
+	SelectMacro(nil)
+
+	--Set config values
+	MegaMacro_BlizMacroCheckbox:SetChecked(MegaMacroConfig["UseNativeMacros"])
+	MegaMacro_BlizActionIconCheckbox:SetChecked(MegaMacroConfig["UseNativeActionBarIcon"])
+
+	MegaMacro_ConfigContainer:Show()
+	MegaMacro_ButtonContainer:Show()
 end
 
 function MegaMacro_FrameTab_OnReceiveDrag(self)
@@ -587,7 +609,7 @@ function MegaMacro_TextBox_TextChanged(self)
     MegaMacro_FrameCharLimitText:SetFormattedText(
 		rendering.CharLimitMessageFormat,
 		MegaMacro_FrameText:GetNumLetters(),
-		MegaMacroCodeMaxLength)
+		MegaMacroConfig['MaxMacroLength'])
 
 	ScrollingEdit_OnTextChanged(self, self:GetParent())
 	ScrollingEdit_OnTextChanged(MegaMacro_FormattedFrameText, MegaMacro_FormattedFrameText:GetParent())
@@ -618,10 +640,32 @@ function MegaMacro_EditButton_OnClick()
 		MegaMacro_PopupEditBox:SetText(SelectedMacro.DisplayName)
 		MegaMacro_FallbackTextureCheckBox:SetChecked(SelectedMacro.IsStaticTextureFallback)
 		MegaMacro_IconSearchBox:SetText("")
+		MegaMacro_DisplayNameLabel:SetText("(#"..SelectedMacro.Id .. ") Display Name")
 		MegaMacro_PopupFrame:Show()
 		PopupMode = PopupModes.Edit
 	end
 end
+
+function MegaMacro_BlizActionIconCheckbox_OnClick()
+	-- Toggle setting and checkbox
+	MegaMacroConfig["UseNativeActionBarIcon"] = not MegaMacroConfig["UseNativeActionBarIcon"]
+	MegaMacro_BlizActionIconCheckbox:SetChecked(MegaMacroConfig["UseNativeActionBarIcon"])
+end
+
+function MegaMacro_BlizMacroCheckbox_OnClick()
+	-- Toggle setting and checkbox
+	MegaMacroConfig["UseNativeMacros"] = not MegaMacroConfig["UseNativeMacros"]
+	MegaMacro_BlizMacroCheckbox:SetChecked(MegaMacroConfig["UseNativeMacros"])
+	-- initialize macros
+	MegaMacroEngine.SafeInitialize()
+	MegaMacro_InitialiseConfig()
+	MegaMacro_FrameCharLimitText:SetFormattedText(
+		rendering.CharLimitMessageFormat,
+		MegaMacro_FrameText:GetNumLetters(),
+		MegaMacroConfig['MaxMacroLength'])
+end
+
+
 
 function MegaMacro_EditOkButton_OnClick()
 	local enteredText = MegaMacro_PopupEditBox:GetText()

--- a/src/windows/mega-macro.window.xml
+++ b/src/windows/mega-macro.window.xml
@@ -1,6 +1,6 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/..\..\FrameXML\UI.xsd">
 	<Script file="src/windows/mega-macro.window.lua"/>
-	<CheckButton name="MegaMacro_ButtonTemplate" inherits="PopupButtonTemplate" virtual="true">
+	<CheckButton name="MegaMacro_ButtonTemplate" inherits="SelectorButtonTemplate" virtual="true">
 		<Scripts>
 			<OnLoad>self:RegisterForDrag("LeftButton");</OnLoad>
 			<OnClick>MegaMacro_MacroButton_OnClick(self);</OnClick>
@@ -9,6 +9,15 @@
 			<OnDragStart>MegaMacro_MacroButton_OnDragStart(self);</OnDragStart>
 			<OnReceiveDrag>MegaMacro_MacroButton_OnReceiveDrag(self);</OnReceiveDrag>
 		</Scripts>
+		<Layers>
+			<Layer level="ARTWORK">
+				<FontString name="$parentName" inherits="GameFontHighlightSmall" text="">
+					<Anchors>
+						<Anchor point="CENTER" relativeTo="$parent" x="0" y="-10"/>
+					</Anchors>
+				</FontString>
+			</Layer>
+		</Layers>
 	</CheckButton>
 	<CheckButton name="MegaMacro_PopupButtonTemplate" inherits="SimplePopupButtonTemplate" virtual="true">
 		<Scripts>
@@ -146,6 +155,16 @@
 					<OnEnter>MegaMacro_FrameSelectedMacroButton_OnEnter();</OnEnter>
 					<OnLeave>MegaMacro_FrameSelectedMacroButton_OnLeave();</OnLeave>
 				</Scripts>
+				<Layers>
+					<Layer level="ARTWORK">
+						<Texture name="MegaMacro_FrameSelectedMacroButtonIcon" file="Interface\Buttons\UI-EmptySlot">
+							<Size x="44" y="44"/>
+							<Anchors>
+								<Anchor point="CENTER" relativeTo="$parent" x="0" y="0"/>
+							</Anchors>
+						</Texture>
+					</Layer>
+				</Layers>
 			</CheckButton>
 			<ScrollFrame name="MegaMacro_ButtonScrollFrame" inherits="UIPanelScrollFrameTemplate">
 				<Size x="593" y="146"/>
@@ -308,14 +327,14 @@
 					<Anchor point="TOPLEFT" relativeTo="MegaMacro_Frame" x="6" y="-289"/>
 				</Anchors>
 			</Frame>
-			<Button name="MegaMacro_FrameTab1" inherits="TabButtonTemplate" text="Global" id="1">
+			<Button name="MegaMacro_FrameTab1" inherits="PanelTabButtonTemplate" text="Global" id="1">
 				<Anchors>
 					<Anchor point="TOPLEFT" x="51" y="-28"/>
 				</Anchors>
 				<Scripts>
 					<OnLoad>
 						PanelTemplates_TabResize(self, -8);
-						_G[self:GetName().."HighlightTexture"]:SetWidth(55);
+<!--						_G[self:GetName().."HighlightTexture"]:SetWidth(55);-->
 					</OnLoad>
 					<OnClick>
 						PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
@@ -324,14 +343,14 @@
 					<OnReceiveDrag>MegaMacro_FrameTab_OnReceiveDrag(self);</OnReceiveDrag>
 				</Scripts>
 			</Button>
-			<Button name="MegaMacro_FrameTab2" inherits="TabButtonTemplate" text="{Class}" id="2">
+			<Button name="MegaMacro_FrameTab2" inherits="PanelTabButtonTemplate" text="{Class}" id="2">
 				<Anchors>
 					<Anchor point="LEFT" relativeTo="MegaMacro_FrameTab1" relativePoint="RIGHT" x="0" y="0"/>
 				</Anchors>
 				<Scripts>
 					<OnLoad>
 						PanelTemplates_TabResize(self, 35);
-						_G[self:GetName().."HighlightTexture"]:SetWidth(103);
+<!--						_G[self:GetName().."HighlightTexture"]:SetWidth(103);-->
 					</OnLoad>
 					<OnClick>
 						PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
@@ -340,14 +359,14 @@
 					<OnReceiveDrag>MegaMacro_FrameTab_OnReceiveDrag(self);</OnReceiveDrag>
 				</Scripts>
 			</Button>
-			<Button name="MegaMacro_FrameTab3" inherits="TabButtonTemplate" text="{Spec}" id="3">
+			<Button name="MegaMacro_FrameTab3" inherits="PanelTabButtonTemplate" text="{Spec}" id="3">
 				<Anchors>
 					<Anchor point="LEFT" relativeTo="MegaMacro_FrameTab2" relativePoint="RIGHT" x="0" y="0"/>
 				</Anchors>
 				<Scripts>
 					<OnLoad>
 						PanelTemplates_TabResize(self, 20);
-						_G[self:GetName().."HighlightTexture"]:SetWidth(82);
+<!--						_G[self:GetName().."HighlightTexture"]:SetWidth(82);-->
 					</OnLoad>
 					<OnClick>
 						PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
@@ -356,14 +375,14 @@
 					<OnReceiveDrag>MegaMacro_FrameTab_OnReceiveDrag(self);</OnReceiveDrag>
 				</Scripts>
 			</Button>
-			<Button name="MegaMacro_FrameTab4" inherits="TabButtonTemplate" text="{Character}" id="4">
+			<Button name="MegaMacro_FrameTab4" inherits="PanelTabButtonTemplate" text="{Character}" id="4">
 				<Anchors>
 					<Anchor point="LEFT" relativeTo="MegaMacro_FrameTab3" relativePoint="RIGHT" x="0" y="0"/>
 				</Anchors>
 				<Scripts>
 					<OnLoad>
 						PanelTemplates_TabResize(self, 20);
-						_G[self:GetName().."HighlightTexture"]:SetWidth(112);
+<!--						_G[self:GetName().."HighlightTexture"]:SetWidth(112);-->
 					</OnLoad>
 					<OnClick>
 						PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
@@ -372,14 +391,14 @@
 					<OnReceiveDrag>MegaMacro_FrameTab_OnReceiveDrag(self);</OnReceiveDrag>
 				</Scripts>
 			</Button>
-			<Button name="MegaMacro_FrameTab5" inherits="TabButtonTemplate" text="{Character Spec}" id="5">
+			<Button name="MegaMacro_FrameTab5" inherits="PanelTabButtonTemplate" text="{Character Spec}" id="5">
 				<Anchors>
 					<Anchor point="LEFT" relativeTo="MegaMacro_FrameTab4" relativePoint="RIGHT" x="0" y="0"/>
 				</Anchors>
 				<Scripts>
 					<OnLoad>
 						PanelTemplates_TabResize(self, 60);
-						_G[self:GetName().."HighlightTexture"]:SetWidth(190);
+<!--						_G[self:GetName().."HighlightTexture"]:SetWidth(190);-->
 					</OnLoad>
 					<OnClick>
 						PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
@@ -551,7 +570,7 @@
 				</Scripts>
 				<FontString inherits="ChatFontNormal"/>
 			</EditBox>
-			<ScrollFrame name="MegaMacro_PopupScrollFrame" inherits="ListScrollFrameTemplate">
+			<ScrollFrame name="MegaMacro_PopupScrollFrame" inherits="UIPanelScrollFrameTemplate2">
 				<Size x="485" y="389"/>
 				<Anchors>
 					<Anchor point="BOTTOMRIGHT" relativeTo="MegaMacro_PopupFrame" x="-36" y="48"/>

--- a/src/windows/mega-macro.window.xml
+++ b/src/windows/mega-macro.window.xml
@@ -12,6 +12,7 @@
 		<Layers>
 			<Layer level="ARTWORK">
 				<FontString name="$parentName" inherits="GameFontHighlightSmall" text="">
+					<Size x="36" y="36"/>
 					<Anchors>
 						<Anchor point="CENTER" relativeTo="$parent" x="0" y="-10"/>
 					</Anchors>
@@ -211,6 +212,54 @@
 							<OnShow>MegaMacro_ButtonContainer_OnShow();</OnShow>
 							<OnReceiveDrag>MegaMacro_ButtonContainer_OnReceiveDrag();</OnReceiveDrag>
 						</Scripts>
+						<Frames>
+							<Frame name="MegaMacro_ConfigContainer" hidden="true">
+								<Size x="439" y="10"/>
+								<Anchors>
+									<Anchor point="TOPLEFT"/>
+								</Anchors>
+								<Frames>
+									<CheckButton name="MegaMacro_BlizMacroCheckbox" frameStrata="HIGH" inherits="UICheckButtonTemplate">
+										<Size x="20" y="20"/>
+										<Anchors>
+											<Anchor point="TOPLEFT" relativeTo="MegaMacro_ConfigContainer" x="0" y="0"/>
+										</Anchors>
+										<Scripts>
+											<OnClick>MegaMacro_BlizMacroCheckbox_OnClick();</OnClick>
+										</Scripts>
+										<Layers>
+										<Layer level="ARTWORK">
+											<FontString name="$parentText" inherits="GameFontNormalSmall" text="Blizzard Style Macros - (Disables some MegaMacro features)">
+												<Anchors>
+													<Anchor point="LEFT" relativeTo="$parent" relativePoint="RIGHT" x="2" y="0"/>
+												</Anchors>
+
+											</FontString>
+										</Layer>
+										</Layers>
+									</CheckButton>
+									<CheckButton name="MegaMacro_BlizActionIconCheckbox" frameStrata="HIGH" inherits="UICheckButtonTemplate">
+										<Size x="20" y="20"/>
+										<Anchors>
+											<Anchor point="TOPLEFT" relativeTo="MegaMacro_ConfigContainer" x="0" y="-24"/>
+										</Anchors>
+										<Scripts>
+											<OnClick>MegaMacro_BlizActionIconCheckbox_OnClick();</OnClick>
+										</Scripts>
+										<Layers>
+										<Layer level="ARTWORK">
+											<FontString name="$parentText" inherits="GameFontNormalSmall" text="Blizzard Action Bar Icons - (Only use with Blizzard Style Macros)">
+												<Anchors>
+													<Anchor point="LEFT" relativeTo="$parent" relativePoint="RIGHT" x="2" y="0"/>
+												</Anchors>
+
+											</FontString>
+										</Layer>
+										</Layers>
+									</CheckButton>
+								</Frames>
+							</Frame>
+						</Frames>
 					</Frame>
 				</ScrollChild>
 			</ScrollFrame>
@@ -405,6 +454,20 @@
 						MegaMacro_FrameTab_OnClick(self);
 					</OnClick>
 					<OnReceiveDrag>MegaMacro_FrameTab_OnReceiveDrag(self);</OnReceiveDrag>
+				</Scripts>
+			</Button>
+			<Button name="MegaMacro_FrameTab6" inherits="PanelTabButtonTemplate" text="Config" id="6">
+				<Anchors>
+					<Anchor point="LEFT" relativeTo="MegaMacro_FrameTab5" relativePoint="RIGHT" x="0" y="0"/>
+				</Anchors>
+				<Scripts>
+					<OnLoad>
+						PanelTemplates_TabResize(self, 60);
+					</OnLoad>
+					<OnClick>
+						PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
+						MegaMacro_FrameTab_OnClick(self);
+					</OnClick>
 				</Scripts>
 			</Button>
 			<Button name="MegaMacro_DeleteButton" inherits="UIPanelButtonTemplate" text="DELETE">

--- a/src/windows/mega-macro.window.xml
+++ b/src/windows/mega-macro.window.xml
@@ -7,6 +7,7 @@
 			<OnEnter>MegaMacro_MacroButton_OnEnter(self);</OnEnter>
 			<OnLeave>MegaMacro_MacroButton_OnLeave(self);</OnLeave>
 			<OnDragStart>MegaMacro_MacroButton_OnDragStart(self);</OnDragStart>
+			<OnDragStop>MegaMacro_MacroButton_OnDragStop(self);</OnDragStop>
 			<OnReceiveDrag>MegaMacro_MacroButton_OnReceiveDrag(self);</OnReceiveDrag>
 		</Scripts>
 		<Layers>
@@ -122,12 +123,6 @@
 				<FontString name="MegaMacro_FrameEnterMacroText" inherits="GameFontHighlightSmall" text="ENTER_MACRO_LABEL">
 					<Anchors>
 						<Anchor point="TOPLEFT" relativeTo="MegaMacro_FrameSelectedMacroBackground" relativePoint="BOTTOMLEFT" x="8" y="3"/>
-					</Anchors>
-				</FontString>
-				<FontString name="MegaMacro_MoveHintText" inherits="GameFontHighlightSmall" text="Move macros by dragging them to another tab." hidden="true">
-					<Size x="0" y="10"/>
-					<Anchors>
-						<Anchor point="CENTER" x="10" y="10"/>
 					</Anchors>
 				</FontString>
 				<FontString name="MegaMacro_FrameCharLimitText" inherits="GameFontHighlightSmall">

--- a/src/windows/mega-macro.window.xml
+++ b/src/windows/mega-macro.window.xml
@@ -277,7 +277,6 @@
 				<Scripts>
 					<OnMouseWheel>
 						ScrollFrameTemplate_OnMouseWheel(self, delta);
-						ScrollFrameTemplate_OnMouseWheel(MegaMacro_FormattedFrameScrollFrame, delta);
 					</OnMouseWheel>
 					<OnVerticalScroll>
 						local scrollbar1 = MegaMacro_FrameScrollFrameScrollBar;
@@ -325,6 +324,11 @@
 			</ScrollFrame>
 			<ScrollFrame name="MegaMacro_FormattedFrameScrollFrame" inherits="UIPanelScrollFrameTemplate">
 				<Size x="591" y="185"/>
+				<Scripts>
+				<OnMouseWheel>
+					ScrollFrameTemplate_OnMouseWheel(self, delta);
+				</OnMouseWheel>
+				</Scripts>
 				<Anchors>
 					<Anchor point="TOPLEFT" relativeTo="MegaMacro_FrameSelectedMacroBackground" relativePoint="BOTTOMLEFT" x="11" y="-13"/>
 				</Anchors>

--- a/src/windows/mega-macro.window.xml
+++ b/src/windows/mega-macro.window.xml
@@ -218,46 +218,6 @@
 								<Anchors>
 									<Anchor point="TOPLEFT"/>
 								</Anchors>
-								<Frames>
-									<CheckButton name="MegaMacro_BlizMacroCheckbox" frameStrata="HIGH" inherits="UICheckButtonTemplate">
-										<Size x="20" y="20"/>
-										<Anchors>
-											<Anchor point="TOPLEFT" relativeTo="MegaMacro_ConfigContainer" x="0" y="0"/>
-										</Anchors>
-										<Scripts>
-											<OnClick>MegaMacro_BlizMacroCheckbox_OnClick();</OnClick>
-										</Scripts>
-										<Layers>
-										<Layer level="ARTWORK">
-											<FontString name="$parentText" inherits="GameFontNormalSmall" text="Blizzard Style Macros - (Disables some MegaMacro features)">
-												<Anchors>
-													<Anchor point="LEFT" relativeTo="$parent" relativePoint="RIGHT" x="2" y="0"/>
-												</Anchors>
-
-											</FontString>
-										</Layer>
-										</Layers>
-									</CheckButton>
-									<CheckButton name="MegaMacro_BlizActionIconCheckbox" frameStrata="HIGH" inherits="UICheckButtonTemplate">
-										<Size x="20" y="20"/>
-										<Anchors>
-											<Anchor point="TOPLEFT" relativeTo="MegaMacro_ConfigContainer" x="0" y="-24"/>
-										</Anchors>
-										<Scripts>
-											<OnClick>MegaMacro_BlizActionIconCheckbox_OnClick();</OnClick>
-										</Scripts>
-										<Layers>
-										<Layer level="ARTWORK">
-											<FontString name="$parentText" inherits="GameFontNormalSmall" text="Blizzard Action Bar Icons - (Only use with Blizzard Style Macros)">
-												<Anchors>
-													<Anchor point="LEFT" relativeTo="$parent" relativePoint="RIGHT" x="2" y="0"/>
-												</Anchors>
-
-											</FontString>
-										</Layer>
-										</Layers>
-									</CheckButton>
-								</Frames>
 							</Frame>
 						</Frames>
 					</Frame>

--- a/src/windows/mega-macro.window.xml
+++ b/src/windows/mega-macro.window.xml
@@ -285,9 +285,9 @@
 			<ScrollFrame name="MegaMacro_FormattedFrameScrollFrame" inherits="UIPanelScrollFrameTemplate">
 				<Size x="591" y="185"/>
 				<Scripts>
-				<OnMouseWheel>
-					ScrollFrameTemplate_OnMouseWheel(self, delta);
-				</OnMouseWheel>
+					<OnMouseWheel>
+						ScrollFrameTemplate_OnMouseWheel(self, delta);
+					</OnMouseWheel>
 				</Scripts>
 				<Anchors>
 					<Anchor point="TOPLEFT" relativeTo="MegaMacro_FrameSelectedMacroBackground" relativePoint="BOTTOMLEFT" x="11" y="-13"/>

--- a/src/windows/mega-macro.window.xml
+++ b/src/windows/mega-macro.window.xml
@@ -11,14 +11,16 @@
 		</Scripts>
 		<Layers>
 			<Layer level="ARTWORK">
-				<FontString name="$parentName" inherits="GameFontHighlightSmall" text="">
-					<Size x="36" y="36"/>
+				<FontString parentKey="Name" inherits="GameFontHighlightSmall" text="">
+					<Size x="36" y="10"/>
 					<Anchors>
-						<Anchor point="CENTER" relativeTo="$parent" x="0" y="-10"/>
+						<Anchor point="BOTTOM" relativeTo="$parent" x="0" y="2"/>
 					</Anchors>
 				</FontString>
 			</Layer>
 		</Layers>
+		<HighlightTexture alphaMode="ADD" file="Interface\Buttons\ButtonHilight-Square"/>
+		<CheckedTexture alphaMode="ADD" file="Interface\Buttons\CheckButtonHilight"/>
 	</CheckButton>
 	<CheckButton name="MegaMacro_PopupButtonTemplate" inherits="SimplePopupButtonTemplate" virtual="true">
 		<Scripts>
@@ -74,8 +76,6 @@
 				end
             </OnHide>
 		</Scripts>
-		<Scripts>
-		</Scripts>
 		<Layers>
 			<Layer level="OVERLAY" textureSubLevel="-1">
 				<Texture name="MegaMacro_FramePortrait" file="Interface\MacroFrame\MacroFrame-Icon">
@@ -122,6 +122,12 @@
 				<FontString name="MegaMacro_FrameEnterMacroText" inherits="GameFontHighlightSmall" text="ENTER_MACRO_LABEL">
 					<Anchors>
 						<Anchor point="TOPLEFT" relativeTo="MegaMacro_FrameSelectedMacroBackground" relativePoint="BOTTOMLEFT" x="8" y="3"/>
+					</Anchors>
+				</FontString>
+				<FontString name="MegaMacro_MoveHintText" inherits="GameFontHighlightSmall" text="Move macros by dragging them to another tab." hidden="true">
+					<Size x="0" y="10"/>
+					<Anchors>
+						<Anchor point="CENTER" x="10" y="10"/>
 					</Anchors>
 				</FontString>
 				<FontString name="MegaMacro_FrameCharLimitText" inherits="GameFontHighlightSmall">

--- a/src/windows/mega-macro.window.xml
+++ b/src/windows/mega-macro.window.xml
@@ -570,7 +570,7 @@
 				</Scripts>
 				<FontString inherits="ChatFontNormal"/>
 			</EditBox>
-			<ScrollFrame name="MegaMacro_PopupScrollFrame" inherits="UIPanelScrollFrameTemplate2">
+			<ScrollFrame name="MegaMacro_PopupScrollFrame" inherits="UIPanelScrollFrameTemplate">
 				<Size x="485" y="389"/>
 				<Anchors>
 					<Anchor point="BOTTOMRIGHT" relativeTo="MegaMacro_PopupFrame" x="-36" y="48"/>
@@ -578,6 +578,11 @@
 				<Scripts>
 					<OnVerticalScroll>FauxScrollFrame_OnVerticalScroll(self, offset, MACRO_ICON_ROW_HEIGHT, MacroPopupFrame_Update);</OnVerticalScroll>
 				</Scripts>
+				<ScrollChild>
+					<Frame name="$parentScrollChildFrame">
+						<Size x="485" y="389"/>
+					</Frame>
+				</ScrollChild>
 			</ScrollFrame>
 		</Frames>
 	</Frame>


### PR DESCRIPTION
New capability to use MegaMacro with the native Blizzard Macros. IE, instead of stubcode replacing blizzard macros, we write the actual macro code, taking only 5 characters at the start to indicate Macro Index. In the process of coding this, many small improvements have been added.

Summary of changes:

**Default to Blizzard Click behaviour.**
    -When macros are below 250 chars, they will automatically be saved as real macros, instead of the MegaMacro variant, allowing for unaltered macro behaviour. This ensures click behaviour works without issue. It also means macros are more easily recovered if MegaMacro breaks (at least for the last used char), since they are bound as regular macros. Longer macros will still bind as 'stubcode'. 
    -This also allows for using Blizzard's Icon rendering. A new config tab contains an option to swap between MegaMacro rendering and Blizzard rendering.


**Improved imports.**
    Imports will no longer fail. Instead, excess macros move to a new 'Inactive' tab to be fixed. 


**Uninstall option.**
    Removes MegaMacro alterations from macro code, allowing for painless uninstall. Of course, if spec/class macros have been added, only those on the current character are kept, since there isn't room for more. Accessed via a button in the config tab.


**Combine Class and Class-Spec tabs**
    There is almost never a need for class-spec when you have a large spec tab already. I merged them and converted the extra tab into the Inactive section.


**Does not automatically use all macros**
    MegaMacro will only create macros as needed, potentially leaving space for other addons to create new macros. This should resolve conflicts with addons like GSE.

**Tab highlighting for Move feature**
    When dragging a macro, relevant tabs will light up, indicating the macro can be dragged to them. This should help make it clear that macros can be moved between tabs.

**Bug Fixes**
    Fixed the highlight border for selected macro
    Fixed multi number modifier strings (stace:1/2/3)
    Fixed highlighting of "known" conditional
    Fixed fallback for missing texture and displayName