### PR TITLE
Update tooltip-functions.lua

### DIFF
--- a/src/tooltip-functions.lua
+++ b/src/tooltip-functions.lua
@@ -9,7 +9,8 @@ function ShowToolTipForMegaMacro(macroId)
 			GameTooltip:SetSpellByID(data.Id)
 			-- GameTooltip:SetToyByItemID(itemId)
 		elseif data.Type == "item" then
-			GameTooltip:SetItemByID(data.Id)
+			GameTooltip:SetInventoryItemByID(data.Id)
+			-- GameTooltip:SetItemByID(data.Id)
 		elseif data.Type == "equipment set" then
 			GameTooltip:SetEquipmentSet(data.Name)
 		else


### PR DESCRIPTION
Fixed macro tooltips displaying the base item info by changing to GameTooltip:SetInventoryItemByID(data.Id). Have been using it like this for about a week now, haven't run into any issues.