### PR TITLE
Fixed tooltip issues introduced in 10.2

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,38 @@
     "Lua.diagnostics.disable": [
         "lowercase-global",
         "unused-function"
+    ],
+    "Lua.diagnostics.globals": [
+        "CooldownFrame_Set",
+        "ActionButton_HideOverlayGlow",
+        "ClearChargeCooldown",
+        "ActionButton_ShowOverlayGlow",
+        "RANGE_INDICATOR",
+        "COOLDOWN_TYPE_LOSS_OF_CONTROL",
+        "COOLDOWN_TYPE_NORMAL",
+        "StartChargeCooldown",
+        "RED_FONT_COLOR",
+        "LIGHTGRAY_FONT_COLOR",
+        "FauxScrollFrame_Update",
+        "BuildIconArray",
+        "FauxScrollFrame_GetOffset",
+        "SpellBook_GetSpellBookSlot",
+        "MAX_SPELLS",
+        "SpellBookFrame",
+        "MacroFrame",
+        "QueryCastSequence",
+        "message",
+        "UIPanelWindows",
+        "UISpecialFrames",
+        "SlashCmdList",
+        "ShowMacroFrame",
+        "GameTooltip_SetDefaultAnchor",
+        "StaticPopupDialogs",
+        "CONFIRM_DELETE_MACRO",
+        "OKAY",
+        "CANCEL",
+        "PanelTemplates_SetNumTabs",
+        "PanelTemplates_SetTab",
+        "ScrollingEdit_OnTextChanged"
     ]
 }

--- a/src/engine/mega-macro-action-bar-engine.lua
+++ b/src/engine/mega-macro-action-bar-engine.lua
@@ -401,8 +401,12 @@ function MegaMacroActionBarEngine.OnUpdate(elapsed)
 
 	iterator(function(button)
 		local action = button:GetAttribute("action") or button.action
+		local macroName = GetActionText(action)
+		local macroCode = GetMacroBody(macroName)
         local type, actionArg1 = GetActionInfo(action)
-        local macroId = type == "macro" and MegaMacroEngine.GetMacroIdFromIndex(actionArg1)
+		-- As of 10.2 GetActionInfo isn't returning the correct value for actionArg1
+        -- local macroId = type == "macro" and MegaMacroEngine.GetMacroIdFromIndex(actionArg1)
+        local macroId = type == "macro" and macroCode and tonumber(string.sub(macroCode, 2, 4))
 
 		if macroId then
 			ActionsBoundToMegaMacros[button] = true


### PR DESCRIPTION
[As of 10.2 GetActionInfo isn't returning the correct value](https://github.com/Stanzilla/WoWUIBugs/issues/495)

GetActionInfo isn't returning the correct value required for MegaMacroEngine.GetMacroIdFromIndex(actionArg1) to get the correct macroId. Instead, we can get the macroId from the macroCode. 