### PR TITLE
Updated for 11.0 The War Within

### DIFF
--- a/MegaMacro.toc
+++ b/MegaMacro.toc
@@ -1,4 +1,4 @@
-## Interface: 100206
+## Interface: 110000
 ## Title: Mega Macro
 ## Author: Sellorio
 ## Version: 1.0.0

--- a/src/constants.lua
+++ b/src/constants.lua
@@ -6,7 +6,7 @@ MacroLimits = {
 	-- limit: 18 character specific macro slots
 	PerCharacterCount = 30,
 	PerCharacterSpecializationCount = 0,
-	InactiveCount = 160,
+	InactiveCount = 150,
 	MaxGlobalMacros = 120,
 	MaxCharacterMacros = 30
 }

--- a/src/constants.lua
+++ b/src/constants.lua
@@ -4,11 +4,11 @@ MacroLimits = {
 	PerClassCount = 30,
 	PerSpecializationCount = 30,
 	-- limit: 18 character specific macro slots
-	PerCharacterCount = 18,
+	PerCharacterCount = 30,
 	PerCharacterSpecializationCount = 0,
 	InactiveCount = 160,
 	MaxGlobalMacros = 120,
-	MaxCharacterMacros = 18
+	MaxCharacterMacros = 30
 }
 
 MacroIndexOffsets = {
@@ -42,7 +42,7 @@ PetActionTextures = {
 
 MegaMacroTexture = 134400
 MegaMacroActiveStanceTexture = 136116
-MegaMacroCodeMaxLength = 1023
+MegaMacroCodeMaxLength = 255
 MegaMacroCodeMaxLengthForNative = 250
 HighestMaxMacroCount = math.max(MacroLimits.GlobalCount, MacroLimits.PerClassCount, MacroLimits.PerSpecializationCount, MacroLimits.PerCharacterCount, MacroLimits.PerCharacterSpecializationCount)
 

--- a/src/constants.lua
+++ b/src/constants.lua
@@ -48,14 +48,19 @@ HighestMaxMacroCount = math.max(MacroLimits.GlobalCount, MacroLimits.PerClassCou
 
 MegaMacroInfoFunctions = {
 	Spell = {
-		GetCooldown = GetSpellCooldown,
-		GetCount = GetSpellCount,
-		GetCharges = function(spellId) return GetSpellCharges(spellId) end,
-		IsUsable = IsUsableSpell,
+		GetCooldown = function(abilityId)
+			local spellCooldownInfo = C_Spell.GetSpellCooldown(abilityId);
+			if spellCooldownInfo then
+				return spellCooldownInfo.startTime, spellCooldownInfo.duration, spellCooldownInfo.isEnabled, spellCooldownInfo.modRate;
+			end
+		end,
+		GetCount = C_Spell.GetSpellCastCount,
+		GetCharges = function(spellId) return C_Spell.GetSpellCharges(spellId) end,
+		IsUsable = C_Spell.IsSpellUsable,
 		IsInRange = function(spellId, target)
 			local spellIndex = FindSpellBookSlotBySpellID(spellId)
 			if spellIndex then
-				local result = IsSpellInRange(spellIndex, "spell", target)
+				local result = C_Spell.IsSpellInRange(spellIndex, "spell", target)
 
 				if result == nil then
 					return nil
@@ -68,23 +73,23 @@ MegaMacroInfoFunctions = {
 		IsEquipped = function(_) return false end,
 		IsAutoRepeat = C_Spell.IsAutoRepeatSpell,
 		IsLocked = C_LevelLink.IsSpellLocked,
-		GetLossOfControlCooldown = GetSpellLossOfControlCooldown,
+		GetLossOfControlCooldown = C_Spell.GetSpellLossOfControlCooldown,
 		IsOverlayed = IsSpellOverlayed
 	},
  	Item = {
-		GetCooldown = GetItemCooldown,
-		GetCount = function(itemId) return GetItemCount(itemId, false, true) end,
+		GetCooldown = C_Item.GetItemCooldown,
+		GetCount = function(itemId) return C_Item.GetItemCount(itemId, false, true) end,
 		GetCharges = function(_) return 0, 0, -1, 0, 1 end, -- charges, maxCharges, chargeStart, chargeDuration, chargeModRate
-		IsUsable = function(itemId) return IsUsableItem(itemId), false end,
+		IsUsable = function(itemId) return C_Item.IsUsableItem(itemId), false end,
 		IsInRange = function(itemId)
-			if GetItemInfo(itemId) then
+			if C_Item.GetItemInfo(itemId) then
 				return function(unit)
-					return IsItemInRange(itemId, unit)
+					return C_Item.IsItemInRange(itemId, unit)
 				end
 			end
 		end,
-		IsCurrent = IsCurrentItem,
-		IsEquipped = function(itemId) return IsEquippedItem(itemId) end,
+		IsCurrent = C_Item.IsCurrentItem,
+		IsEquipped = function(itemId) return C_Item.IsEquippedItem(itemId) end,
 		IsAutoRepeat = function(_) return false end,
 		IsLocked = function(_) return false end,
 		GetLossOfControlCooldown = function(_) return -1, 0 end,

--- a/src/constants.lua
+++ b/src/constants.lua
@@ -6,7 +6,7 @@ MacroLimits = {
 	-- limit: 18 character specific macro slots
 	PerCharacterCount = 30,
 	PerCharacterSpecializationCount = 0,
-	InactiveCount = 150,
+	InactiveCount = 160,
 	MaxGlobalMacros = 120,
 	MaxCharacterMacros = 30
 }

--- a/src/constants.lua
+++ b/src/constants.lua
@@ -64,9 +64,9 @@ MegaMacroInfoFunctions = {
 				end
             end
 		end,
-		IsCurrent = IsCurrentSpell,
+		IsCurrent = C_Spell.IsCurrentSpell,
 		IsEquipped = function(_) return false end,
-		IsAutoRepeat = IsAutoRepeatSpell,
+		IsAutoRepeat = C_Spell.IsAutoRepeatSpell,
 		IsLocked = C_LevelLink.IsSpellLocked,
 		GetLossOfControlCooldown = GetSpellLossOfControlCooldown,
 		IsOverlayed = IsSpellOverlayed

--- a/src/engine/mega-macro-action-bar-engine.lua
+++ b/src/engine/mega-macro-action-bar-engine.lua
@@ -20,7 +20,7 @@ For developer refererence, these are the features of an action bar button:
 
 local LibActionButton = nil
 local ActionBarSystem = nil -- Blizzard or LAB or Dominos
-local BlizzardActionBars = { "Action", "MultiBarBottomLeft", "MultiBarBottomRight", "MultiBarRight", "MultiBarLeft" }
+local BlizzardActionBars = { "Action", "MultiBarBottomLeft", "MultiBarBottomRight", "MultiBarRight", "MultiBarLeft", "MultiBar5", "MultiBar6", "MultiBar7" }
 
 local rangeTimer = 5
 local updateRange = false

--- a/src/engine/mega-macro-action-bar-engine.lua
+++ b/src/engine/mega-macro-action-bar-engine.lua
@@ -190,7 +190,7 @@ local function UpdateCount(button, functions, abilityId)
     local countLabel = button.Count
     local count = functions.GetCount(abilityId)
 
-    local isNonEquippableItem = functions == MegaMacroInfoFunctions.Item and not IsEquippableItem(abilityId)
+    local isNonEquippableItem = functions == MegaMacroInfoFunctions.Item and not C_Item.IsEquippableItem(abilityId)
     local isNonItemWithCount = functions ~= MegaMacroInfoFunctions.Item and count and count > 0
 
     if isNonEquippableItem or isNonItemWithCount then
@@ -235,6 +235,8 @@ end
 
 local function UpdateRange(button, functions, abilityId, target)
     local valid = functions.IsInRange(abilityId, target)
+    -- local valid = IsSpellInRange(spellName, target) or IsItemInRange(abilityId, target)
+	-- local valid = true
     local checksRange = (valid ~= nil);
     local inRange = checksRange and valid;
 	rangeTimer = 1;
@@ -278,10 +280,6 @@ local function UpdateRange(button, functions, abilityId, target)
 end
 
 local function UpdateActionBar(button, macroId)
-	if MegaMacroConfig['UseNativeActionBar'] then
-		return
-	end
-
     local data = MegaMacroIconEvaluator.GetCachedData(macroId)
     local functions = MegaMacroInfoFunctions.Unknown
 
@@ -316,9 +314,6 @@ local function UpdateActionBar(button, macroId)
 end
 
 local function ResetActionBar(button)
-	if MegaMacroConfig['UseNativeActionBar'] then
-		return
-	end
 	button:SetChecked(false)
 	button.Count:SetText("")
 	button.Border:Hide() -- reset eqipped border
@@ -397,7 +392,7 @@ end
 function MegaMacroActionBarEngine.OnUpdate(elapsed)
     UpdateRangeTimer(elapsed)
 
-    local focus = GetMouseFocus()
+    local focus = GetMouseFoci()[1]
 	local iterator = ForEachBlizzardActionButton
 	
 	if ActionBarSystem == "LAB" then

--- a/src/engine/mega-macro-icon-evaluator.lua
+++ b/src/engine/mega-macro-icon-evaluator.lua
@@ -72,7 +72,8 @@ local function GetAbilityData(ability)
             return "unknown", nil, nil, MegaMacroTexture
         end
     else
-        local spellName, _, texture, _, _, _, spellId = C_Spell.GetSpellInfo(ability)
+        local spellInfo = C_Spell.GetSpellInfo(ability)
+        local spellName, _, texture, _, _, _, spellId = spellInfo.name, nil, spellInfo.iconID, spellInfo.castTime, spellInfo.minRange, spellInfo.maxRange, spellInfo.spellID
         if spellId then
             local shapeshiftFormIndex = GetShapeshiftForm()
             local isActiveStance = shapeshiftFormIndex and shapeshiftFormIndex > 0 and spellId == select(4, GetShapeshiftFormInfo(shapeshiftFormIndex))

--- a/src/engine/mega-macro-icon-evaluator.lua
+++ b/src/engine/mega-macro-icon-evaluator.lua
@@ -66,13 +66,13 @@ local function GetAbilityData(ability)
     if slotId then
         local itemId = GetInventoryItemID("player", slotId)
         if itemId then
-            local itemName, _, _, _, _, _, _, _, _, itemTexture = GetItemInfo(itemId)
+            local itemName, _, _, _, _, _, _, _, _, itemTexture = C_Item.GetItemInfo(itemId)
             return "item", itemId, itemName, itemTexture
         else
             return "unknown", nil, nil, MegaMacroTexture
         end
     else
-        local spellName, _, texture, _, _, _, spellId = GetSpellInfo(ability)
+        local spellName, _, texture, _, _, _, spellId = C_Spell.GetSpellInfo(ability)
         if spellId then
             local shapeshiftFormIndex = GetShapeshiftForm()
             local isActiveStance = shapeshiftFormIndex and shapeshiftFormIndex > 0 and spellId == select(4, GetShapeshiftFormInfo(shapeshiftFormIndex))

--- a/src/engine/mega-macro-icon-evaluator.lua
+++ b/src/engine/mega-macro-icon-evaluator.lua
@@ -80,10 +80,10 @@ local function GetAbilityData(ability)
         end
 
         local itemId
-        itemId, _, _, _, texture = GetItemInfoInstant(ability)
+        itemId, _, _, _, texture = C_Item.GetItemInfoInstant(ability)
         if texture then
             if C_ToyBox.GetToyInfo(itemId) then
-                spellName, spellId = GetItemSpell(itemId)
+                spellName, spellId = C_Item.GetItemSpell(itemId)
                 if spellId then
                     return "spell", spellId, spellName, texture
                 end

--- a/src/engine/mega-macro-icon-evaluator.lua
+++ b/src/engine/mega-macro-icon-evaluator.lua
@@ -73,6 +73,9 @@ local function GetAbilityData(ability)
         end
     else
         local spellInfo = C_Spell.GetSpellInfo(ability)
+        if (spellInfo == nil) then
+            return
+        end
         local spellName, _, texture, _, _, _, spellId = spellInfo.name, nil, spellInfo.iconID, spellInfo.castTime, spellInfo.minRange, spellInfo.maxRange, spellInfo.spellID
         if spellId then
             local shapeshiftFormIndex = GetShapeshiftForm()

--- a/src/engine/parsing/conditions.lua
+++ b/src/engine/parsing/conditions.lua
@@ -263,6 +263,7 @@ end
 
 local Conditionals = {
 	actionbar = NoModifier,
+	advflyable = NoModifier,
 	bar = NumberModifier,
 	bonusbar = NumberModifier,
 	btn = MouseButtonModifier,

--- a/src/engine/parsing/parsing-functions.lua
+++ b/src/engine/parsing/parsing-functions.lua
@@ -22,7 +22,14 @@ local function ParseResult(parsingContext, length, colour)
     end
     local text = string.sub(parsingContext.Code, parsingContext.Index, parsingContext.Index + length - 1)
     parsingContext.Index = parsingContext.Index + length
-    return colour and "|c"..colour..text.."|r" or text
+
+    if parsingContext.Index > 256 then
+        local validText = #text - (parsingContext.Index - 256) >= 1 and text:sub(1, #text - (parsingContext.Index - 256)) or ""
+        local overflowText = #validText > 0 and text:sub(#text - (parsingContext.Index - 257)) or text
+        return validText .. "|c"..GetMegaMacroParsingColourData().Error..overflowText.."|r"
+    else
+        return colour and "|c"..colour..text.."|r" or text
+    end
 end
 
 function GetMegaMacroParsingFunctions()

--- a/src/main.lua
+++ b/src/main.lua
@@ -74,3 +74,6 @@ f:SetScript("OnEvent", function(self, event)
 end)
 
 MegaMacro_RegisterShiftClicks()
+
+tinsert(UISpecialFrames, "MegaMacro_Frame")
+UIPanelWindows["MegaMacro_Frame"] = nil

--- a/src/mega-macro-icon-navigator.lua
+++ b/src/mega-macro-icon-navigator.lua
@@ -91,6 +91,9 @@ function MegaMacroIconNavigator.OnUpdate()
         for _=1, FetchesPerFrame do
             CurrentSpellId = CurrentSpellId + 1
             local spellInfo = C_Spell.GetSpellInfo(CurrentSpellId)
+            if (spellInfo == nil) then
+                return
+            end
             local name, _, icon, _, _, _, spellId = spellInfo.name, nil, spellInfo.iconID, spellInfo.castTime, spellInfo.minRange, spellInfo.maxRange, spellInfo.spellID
 
             if icon == 136243 then

--- a/src/mega-macro-icon-navigator.lua
+++ b/src/mega-macro-icon-navigator.lua
@@ -22,15 +22,19 @@ local function GetDefaultIconList()
 	-- We need to avoid adding duplicate spellIDs from the spellbook tabs for your other specs.
 	local activeIcons = {};
 
-	for i = 1, GetNumSpellTabs() do
-		local tab, tabTex, offset, numSpells, _ = GetSpellTabInfo(i);
+	for i = 1, C_SpellBook.GetNumSpellBookSkillLines() do
+        local skillLine = C_SpellBook.GetSpellBookSkillLineInfo(i)
+        local tab = skillLine.name
+        local tabTex = skillLine.iconID
+        local offset = skillLine.itemIndexOffset
+        local numSpells = skillLine.numSpellBookItems
 		offset = offset + 1;
 		local tabEnd = offset + numSpells;
 		for j = offset, tabEnd - 1 do
 			--to get spell info by slot, you have to pass in a pet argument
-			local spellType, ID = GetSpellBookItemInfo(j, "player");
+			local spellType, ID = C_SpellBook.GetSpellBookItemType(j, Enum.SpellBookSpellBank.Player);
 			if (spellType ~= "FUTURESPELL") then
-				local fileID = GetSpellBookItemTexture(j, "player");
+				local fileID = C_SpellBook.GetSpellBookItemTexture(j, Enum.SpellBookSpellBank.Player);
 				if (fileID) then
 					activeIcons[fileID] = true;
 				end
@@ -86,7 +90,7 @@ function MegaMacroIconNavigator.OnUpdate()
     if IconLoadingStarted and not IconLoadingFinished then
         for _=1, FetchesPerFrame do
             CurrentSpellId = CurrentSpellId + 1
-            local name, _, icon, _, _, _, spellId = GetSpellInfo(CurrentSpellId)
+            local name, _, icon, _, _, _, spellId = C_Spell.GetSpellInfo(CurrentSpellId)
 
             if icon == 136243 then
                 -- 136243 is the a gear icon, we can ignore those spells (courtesy of WeakAuras)

--- a/src/mega-macro-icon-navigator.lua
+++ b/src/mega-macro-icon-navigator.lua
@@ -90,7 +90,8 @@ function MegaMacroIconNavigator.OnUpdate()
     if IconLoadingStarted and not IconLoadingFinished then
         for _=1, FetchesPerFrame do
             CurrentSpellId = CurrentSpellId + 1
-            local name, _, icon, _, _, _, spellId = C_Spell.GetSpellInfo(CurrentSpellId)
+            local spellInfo = C_Spell.GetSpellInfo(CurrentSpellId)
+            local name, _, icon, _, _, _, spellId = spellInfo.name, nil, spellInfo.iconID, spellInfo.castTime, spellInfo.minRange, spellInfo.maxRange, spellInfo.spellID
 
             if icon == 136243 then
                 -- 136243 is the a gear icon, we can ignore those spells (courtesy of WeakAuras)

--- a/src/windows/mega-macro.window.lua
+++ b/src/windows/mega-macro.window.lua
@@ -92,7 +92,7 @@ local function InitializeTabs()
 	MegaMacro_FrameTab4:SetText(playerName)
 	MegaMacro_FrameTab5:SetText("Inactive")
 	MegaMacro_FrameTab6:SetText("Config")
-	
+
 	if MegaMacroCachedSpecialization == '' then
 		MegaMacro_FrameTab3:SetText("Locked")
 		MegaMacro_FrameTab3:Disable()
@@ -285,7 +285,7 @@ local function DeleteMegaMacro()
 end
 
 local function UpdateTooltipIfButtonIsHovered(updatedMacroId)
-	local mouseFocus = GetMouseFocus()
+	local mouseFocus = GetMouseFoci()[1]
 
 	if mouseFocus then
 		local focusFrame = mouseFocus:GetName()
@@ -501,7 +501,7 @@ function MegaMacro_FrameTab_OnClick(self)
 			MegaMacro_FrameTab_ShowConfig()
 			return
 		end
-		
+
 		SelectedScope = scope
 		SelectedTabIndex = tabIndex
 

--- a/src/windows/mega-macro.window.lua
+++ b/src/windows/mega-macro.window.lua
@@ -630,7 +630,9 @@ function MegaMacro_TextBox_TextChanged(self)
 		MegaMacro_FrameText:GetNumLetters(),
 		MegaMacroCodeMaxLength)
 	-- Set color of text based on length
-	if MegaMacro_FrameText:GetNumLetters() > MegaMacroCodeMaxLengthForNative then
+	if MegaMacro_FrameText:GetNumLetters() > MegaMacroCodeMaxLength then
+		MegaMacro_FrameCharLimitText:SetTextColor(1, 0.267, 0.267)
+	elseif MegaMacro_FrameText:GetNumLetters() > MegaMacroCodeMaxLengthForNative then
 		MegaMacro_FrameCharLimitText:SetTextColor(1, 0.85, 0)
 	else
 		MegaMacro_FrameCharLimitText:SetTextColor(1,1,1) --0.2, 0.867, 1.0

--- a/src/windows/mega-macro.window.xml
+++ b/src/windows/mega-macro.window.xml
@@ -266,7 +266,7 @@
 					<Anchor point="TOPLEFT" relativeTo="MegaMacro_FrameSelectedMacroBackground" relativePoint="BOTTOMLEFT" x="11" y="-13"/>
 				</Anchors>
 				<ScrollChild>
-					<EditBox name="MegaMacro_FrameText" multiLine="true" letters="255" autoFocus="false" countInvisibleLetters="true">
+					<EditBox name="MegaMacro_FrameText" multiLine="true" letters="1023" autoFocus="false" countInvisibleLetters="true">
 						<Size x="589" y="185"/>
 						<Scripts>
 							<OnLoad>

--- a/src/windows/mega-macro.window.xml
+++ b/src/windows/mega-macro.window.xml
@@ -266,7 +266,7 @@
 					<Anchor point="TOPLEFT" relativeTo="MegaMacro_FrameSelectedMacroBackground" relativePoint="BOTTOMLEFT" x="11" y="-13"/>
 				</Anchors>
 				<ScrollChild>
-					<EditBox name="MegaMacro_FrameText" multiLine="true" letters="1023" autoFocus="false" countInvisibleLetters="true">
+					<EditBox name="MegaMacro_FrameText" multiLine="true" letters="255" autoFocus="false" countInvisibleLetters="true">
 						<Size x="589" y="185"/>
 						<Scripts>
 							<OnLoad>


### PR DESCRIPTION
With The War Within Blizzard have made some changes to how macros work. 

The length of macros executable by "macrotext" is being restricted to 255 characters, and all macros (both real and "macrotext" based ones) are being restricted to remove the ability to chain macros. This means that one macro cannot "/click" a button that itself would execute another macro.
https://github.com/Stanzilla/WoWUIBugs/issues/552#issuecomment-2192109095

This pull request changes several constants to handle this change. Additionally, it moves refactors several functions into the appropriate namespaces Blizzard has introduced.

