### PR TITLE
Several minor fixes incl. issue 224

### DIFF
--- a/src/constants.lua
+++ b/src/constants.lua
@@ -42,7 +42,7 @@ PetActionTextures = {
 
 MegaMacroTexture = 134400
 MegaMacroActiveStanceTexture = 136116
-MegaMacroCodeMaxLength = 255
+MegaMacroCodeMaxLength = 250
 MegaMacroCodeMaxLengthForNative = 250
 HighestMaxMacroCount = math.max(MacroLimits.GlobalCount, MacroLimits.PerClassCount, MacroLimits.PerSpecializationCount, MacroLimits.PerCharacterCount, MacroLimits.PerCharacterSpecializationCount)
 

--- a/src/engine/mega-macro-icon-evaluator.lua
+++ b/src/engine/mega-macro-icon-evaluator.lua
@@ -73,10 +73,14 @@ local function GetAbilityData(ability)
         end
     else
         local spellInfo = C_Spell.GetSpellInfo(ability)
-        if (spellInfo == nil) then
-            return
+        local spellName, texture, spellId
+
+        if spellInfo then
+            spellName = spellInfo.name
+            texture = spellInfo.iconID
+            spellId = spellInfo.spellID
         end
-        local spellName, _, texture, _, _, _, spellId = spellInfo.name, nil, spellInfo.iconID, spellInfo.castTime, spellInfo.minRange, spellInfo.maxRange, spellInfo.spellID
+
         if spellId then
             local shapeshiftFormIndex = GetShapeshiftForm()
             local isActiveStance = shapeshiftFormIndex and shapeshiftFormIndex > 0 and spellId == select(4, GetShapeshiftFormInfo(shapeshiftFormIndex))

--- a/src/engine/parsing/parsing-functions.lua
+++ b/src/engine/parsing/parsing-functions.lua
@@ -23,9 +23,9 @@ local function ParseResult(parsingContext, length, colour)
     local text = string.sub(parsingContext.Code, parsingContext.Index, parsingContext.Index + length - 1)
     parsingContext.Index = parsingContext.Index + length
 
-    if parsingContext.Index > 256 then
-        local validText = #text - (parsingContext.Index - 256) >= 1 and text:sub(1, #text - (parsingContext.Index - 256)) or ""
-        local overflowText = #validText > 0 and text:sub(#text - (parsingContext.Index - 257)) or text
+    if parsingContext.Index > (MegaMacroCodeMaxLengthForNative + 1) then
+        local validText = #text - (parsingContext.Index - (MegaMacroCodeMaxLengthForNative + 1)) >= 1 and text:sub(1, #text - (parsingContext.Index - (MegaMacroCodeMaxLengthForNative + 1))) or ""
+        local overflowText = #validText > 0 and text:sub(#text - (parsingContext.Index - (MegaMacroCodeMaxLengthForNative + 2))) or text
         return validText .. "|c"..GetMegaMacroParsingColourData().Error..overflowText.."|r"
     else
         return colour and "|c"..colour..text.."|r" or text

--- a/src/tooltip-functions.lua
+++ b/src/tooltip-functions.lua
@@ -9,7 +9,8 @@ function ShowToolTipForMegaMacro(macroId)
 			GameTooltip:SetSpellByID(data.Id)
 			-- GameTooltip:SetToyByItemID(itemId)
 		elseif data.Type == "item" then
-			GameTooltip:SetItemByID(data.Id)
+			-- GameTooltip:SetItemByID(data.Id)
+            GameTooltip:SetInventoryItemByID(data.Id)
 		elseif data.Type == "equipment set" then
 			GameTooltip:SetEquipmentSet(data.Name)
 		else


### PR DESCRIPTION
As requested, MegaMacro window now displays /250 instead of /255.

Fixed GetAbilityData returning early, preventing icons for item macros from displaying.

Fixed macro tooltip displaying item info for the base item iLevel instead of the equipped item iLevel.